### PR TITLE
[FEAT] 장소 검색 결과 무한 스크롤 기능 추가

### DIFF
--- a/frontend/lib/features/navigation/add_place_screen.dart
+++ b/frontend/lib/features/navigation/add_place_screen.dart
@@ -40,6 +40,9 @@ class _AddPlaceScreenState extends State<AddPlaceScreen> {
   /// 검색 관련 상태
   List<Map<String, dynamic>> searchResults = [];
   bool isLoading = false;
+  bool _isLoadingMore = false;
+  bool _hasNext = false;
+  int _currentPage = 1;
   bool _isSelecting = false;
   Timer? _debounce;
 
@@ -82,26 +85,33 @@ class _AddPlaceScreenState extends State<AddPlaceScreen> {
     }
   }
 
-  /// 장소 검색
+  /// 장소 검색 (새 쿼리 입력 시 초기화)
   Future<void> searchPlaces(String query) async {
     if (query.trim().isEmpty) {
       setState(() {
         searchResults.clear();
+        _hasNext = false;
+        _currentPage = 1;
       });
       return;
     }
 
     try {
-      setState(() => isLoading = true);
+      setState(() {
+        isLoading = true;
+        _currentPage = 1;
+      });
 
-      final results = await PlaceService.searchPlaces(
+      final result = await PlaceService.searchPlaces(
         query: query,
         lat: _currentPosition?.latitude ?? 37.5665,
         lng: _currentPosition?.longitude ?? 126.9780,
+        page: 1,
       );
 
       setState(() {
-        searchResults = results;
+        searchResults = List<Map<String, dynamic>>.from(result['items']);
+        _hasNext = result['hasNext'] as bool;
         isLoading = false;
       });
     } catch (e) {
@@ -109,6 +119,33 @@ class _AddPlaceScreenState extends State<AddPlaceScreen> {
       setState(() {
         isLoading = false;
       });
+    }
+  }
+
+  /// 추가 페이지 로드 (무한 스크롤)
+  Future<void> _loadMorePlaces() async {
+    if (!_hasNext || _isLoadingMore) return;
+
+    try {
+      setState(() => _isLoadingMore = true);
+
+      final nextPage = _currentPage + 1;
+      final result = await PlaceService.searchPlaces(
+        query: destinationController.text,
+        lat: _currentPosition?.latitude ?? 37.5665,
+        lng: _currentPosition?.longitude ?? 126.9780,
+        page: nextPage,
+      );
+
+      setState(() {
+        searchResults.addAll(List<Map<String, dynamic>>.from(result['items']));
+        _hasNext = result['hasNext'] as bool;
+        _currentPage = nextPage;
+        _isLoadingMore = false;
+      });
+    } catch (e) {
+      debugPrint('🔴 추가 장소 로드 에러: $e');
+      setState(() => _isLoadingMore = false);
     }
   }
 
@@ -218,6 +255,8 @@ class _AddPlaceScreenState extends State<AddPlaceScreen> {
                                 currentLocation = "위치를 검색하세요.";
                                 searchResults.clear();
                                 isLoading = false;
+                                _hasNext = false;
+                                _currentPage = 1;
                               });
                             },
                             onMicTap: () =>
@@ -279,6 +318,8 @@ class _AddPlaceScreenState extends State<AddPlaceScreen> {
                       : searchResults.isNotEmpty
                       ? ResultList(
                           results: searchResults,
+                          isLoadingMore: _isLoadingMore,
+                          onLoadMore: _loadMorePlaces,
                           onTap: (item) {
                             FocusManager.instance.primaryFocus?.unfocus();
 

--- a/frontend/lib/features/navigation/navigation_result_list.dart
+++ b/frontend/lib/features/navigation/navigation_result_list.dart
@@ -2,11 +2,46 @@ import 'package:flutter/material.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 
-class ResultList extends StatelessWidget {
+class ResultList extends StatefulWidget {
   final List<Map<String, dynamic>> results;
   final Function(Map<String, dynamic>) onTap;
+  final VoidCallback onLoadMore;
+  final bool isLoadingMore;
 
-  const ResultList({super.key, required this.results, required this.onTap});
+  const ResultList({
+    super.key,
+    required this.results,
+    required this.onTap,
+    required this.onLoadMore,
+    this.isLoadingMore = false,
+  });
+
+  @override
+  State<ResultList> createState() => _ResultListState();
+}
+
+class _ResultListState extends State<ResultList> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 80) {
+      widget.onLoadMore();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -27,12 +62,20 @@ class ResultList extends StatelessWidget {
       ),
       constraints: const BoxConstraints(maxHeight: 600),
       child: ListView.separated(
+        controller: _scrollController,
         shrinkWrap: true,
         physics: const BouncingScrollPhysics(),
-        itemCount: results.length,
+        itemCount: widget.results.length + (widget.isLoadingMore ? 1 : 0),
         separatorBuilder: (_, __) => const Divider(height: 1),
         itemBuilder: (context, index) {
-          final item = results[index];
+          if (index == widget.results.length) {
+            return const Padding(
+              padding: EdgeInsets.symmetric(vertical: 12),
+              child: Center(child: CircularProgressIndicator()),
+            );
+          }
+
+          final item = widget.results[index];
 
           return ListTile(
             contentPadding: const EdgeInsets.symmetric(horizontal: 16),
@@ -58,7 +101,7 @@ class ResultList extends StatelessWidget {
                 color: ColorCollection.point,
               ),
             ),
-            onTap: () => onTap(item),
+            onTap: () => widget.onTap(item),
           );
         },
       ),

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -34,6 +34,9 @@ class _NavigationScreenState extends State<NavigationScreen> {
   String currentLocation = "현재 위치 불러오는 중...";
   String selectedLocation = "목적지를 선택해 주세요.";
   List<Map<String, dynamic>> searchResults = [];
+  bool _hasNext = false;
+  int _currentPage = 1;
+  bool _isLoadingMore = false;
   Timer? _debounce;
   Position? _currentPosition;
   bool isLoading = false;
@@ -175,11 +178,13 @@ class _NavigationScreenState extends State<NavigationScreen> {
     }
   }
 
-  /// 장소 검색 함수
+  /// 장소 검색 함수 (새 쿼리 입력 시 초기화)
   void searchPlaces() async {
     if (destinationController.text.trim().isEmpty) {
       setState(() {
         searchResults.clear();
+        _hasNext = false;
+        _currentPage = 1;
       });
       return;
     }
@@ -189,16 +194,21 @@ class _NavigationScreenState extends State<NavigationScreen> {
         _currentPosition = await getCurrentLocation();
       }
 
-      setState(() => isLoading = true);
+      setState(() {
+        isLoading = true;
+        _currentPage = 1;
+      });
 
-      final results = await PlaceService.searchPlaces(
+      final result = await PlaceService.searchPlaces(
         query: destinationController.text,
         lat: _currentPosition!.latitude,
         lng: _currentPosition!.longitude,
+        page: 1,
       );
 
       setState(() {
-        searchResults = results;
+        searchResults = List<Map<String, dynamic>>.from(result['items']);
+        _hasNext = result['hasNext'] as bool;
         isLoading = false;
       });
     } catch (e) {
@@ -206,6 +216,33 @@ class _NavigationScreenState extends State<NavigationScreen> {
       setState(() {
         isLoading = false;
       });
+    }
+  }
+
+  /// 추가 페이지 로드 (무한 스크롤)
+  Future<void> _loadMorePlaces() async {
+    if (!_hasNext || _isLoadingMore) return;
+
+    try {
+      setState(() => _isLoadingMore = true);
+
+      final nextPage = _currentPage + 1;
+      final result = await PlaceService.searchPlaces(
+        query: destinationController.text,
+        lat: _currentPosition!.latitude,
+        lng: _currentPosition!.longitude,
+        page: nextPage,
+      );
+
+      setState(() {
+        searchResults.addAll(List<Map<String, dynamic>>.from(result['items']));
+        _hasNext = result['hasNext'] as bool;
+        _currentPage = nextPage;
+        _isLoadingMore = false;
+      });
+    } catch (e) {
+      debugPrint('🔴 [Place] 추가 장소 로드 에러: $e');
+      setState(() => _isLoadingMore = false);
     }
   }
 
@@ -236,6 +273,8 @@ class _NavigationScreenState extends State<NavigationScreen> {
                           selectedLocation = "목적지를 선택해 주세요.";
                           searchResults.clear();
                           isLoading = false;
+                          _hasNext = false;
+                          _currentPage = 1;
                         });
                       },
                       hintText: '목적지를 입력하세요.',
@@ -366,6 +405,8 @@ class _NavigationScreenState extends State<NavigationScreen> {
                       : searchResults.isNotEmpty
                       ? ResultList(
                           results: searchResults,
+                          isLoadingMore: _isLoadingMore,
+                          onLoadMore: _loadMorePlaces,
                           onTap: (item) {
                             FocusManager.instance.primaryFocus?.unfocus();
 

--- a/frontend/lib/service/place_service.dart
+++ b/frontend/lib/service/place_service.dart
@@ -37,7 +37,8 @@ class PlaceService {
   }
 
   /// 장소 검색 API
-  static Future<List<Map<String, dynamic>>> searchPlaces({
+  /// 반환값: {'items': List<Map>, 'hasNext': bool}
+  static Future<Map<String, dynamic>> searchPlaces({
     required String query,
     required double lat,
     required double lng,
@@ -67,24 +68,29 @@ class PlaceService {
         final data = jsonDecode(response.body);
 
         if (data['success']) {
-          final items = data['data']['items'] as List;
-
-          return items.map<Map<String, dynamic>>((item) {
+          final pageData = data['data'];
+          final items = (pageData['items'] as List).map<Map<String, dynamic>>((item) {
             return {
+              'id': item['placeId'],
               'name': item['name'],
               'roadAddress': item['roadAddress'],
-              'distance': item['distanceMeters'],
-              'lat': item['latitude'],
-              'lng': item['longitude'],
+              'distance': item['distanceM'],
+              'latitude': item['lat'],
+              'longitude': item['lng'],
             };
           }).toList();
+
+          return {
+            'items': items,
+            'hasNext': pageData['hasNext'] as bool,
+          };
         }
       }
 
-      return [];
+      return {'items': <Map<String, dynamic>>[], 'hasNext': false};
     } catch (e) {
       debugPrint('🔴 [Place] searchPlaces error: $e');
-      return [];
+      return {'items': <Map<String, dynamic>>[], 'hasNext': false};
     }
   }
 


### PR DESCRIPTION
## 📎 Issue 번호
#11 

## 📄 작업 내용 요약
- `ResultList` 위젯을 `StatefulWidget`으로 변환하고 무한 스크롤 기능을 추가                                                                                                                            
- `PlaceService.searchPlaces`에 페이지네이션 지원 추가 (반환 타입 변경)                                                                                                                                
- `NavigationScreen`, `AddPlaceScreen` 양쪽에 무한 스크롤 상태 관리 추가  

## 📸 스크린샷 (UI 변경 시 작성, 없으면 삭제)
<img width=50% alt="Screenshot_20260412_180602" src="https://github.com/user-attachments/assets/d0545933-1c68-414d-b6a7-349f9e0775c1" />

## ✅ 체크리스트
- [x] 장소 검색 후 스크롤을 끝까지 내렸을 때 추가 결과가 로드되는지 확인                                                                                                                               
- [x] 마지막 페이지(`hasNext: false`)에서 더 이상 요청이 발생하지 않는지 확인                                                                                                                          
- [x] 새 검색어 입력 시 기존 결과 및 페이지 상태가 초기화되는지 확인                                                                                                                                   
- [x] `NavigationScreen`, `AddPlaceScreen` 양쪽 모두 동일하게 동작하는지 확인
