### PR TITLE
[FIX] 길찾기 중 화면 landscape view 레이아웃 변경

### DIFF
--- a/frontend/lib/common/widgets/action_button_widget.dart
+++ b/frontend/lib/common/widgets/action_button_widget.dart
@@ -67,10 +67,13 @@ class ActionButton extends StatelessWidget {
                 Icon(icon, color: iconColor, size: iconSize),
                 const SizedBox(width: 6),
               ],
-              Text(
-                label,
-                style: (textStyle ?? AppTextStyles.title2).copyWith(
-                  color: textColor,
+              Flexible(
+                child: Text(
+                  label,
+                  textAlign: TextAlign.center,
+                  style: (textStyle ?? AppTextStyles.title2).copyWith(
+                    color: textColor,
+                  ),
                 ),
               ),
             ],

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -1,12 +1,12 @@
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:safepath/common/theme/color_collection.dart';
-import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/common/widgets/action_button_widget.dart';
-import 'package:safepath/common/widgets/title_bar_widget.dart';
 import 'package:safepath/features/navigation/navigation_step_card.dart';
 import 'package:safepath/features/navigation/navigation_voiceguide_card.dart';
-import 'package:safepath/routes/app_router.dart';
 import 'package:safepath/features/navigation/navigation_overview_card.dart';
+import 'dart:ui' show DisplayFeatureType;
+import 'package:flutter/services.dart';
 
 class NavigationIngScreen extends StatefulWidget {
   const NavigationIngScreen({super.key});
@@ -17,54 +17,119 @@ class NavigationIngScreen extends StatefulWidget {
 
 class _NavigationIngScreenState extends State<NavigationIngScreen> {
   @override
+  void initState() {
+    super.initState();
+    // 가로 모드로 고정
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.landscapeRight,
+    ]);
+  }
+
+  @override
+  void dispose() {
+    // 다시 세로 모드 허용
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final mq = MediaQuery.of(context);
+    final vp = mq.viewPadding;
+    final size = mq.size;
+
+    // viewPadding이 0인 기기에서도 displayFeatures로 실제 카메라 cutout 영역을 감지
+    double cutoutLeft = 0, cutoutTop = 0, cutoutRight = 0;
+    for (final feature in mq.displayFeatures) {
+      if (feature.type == DisplayFeatureType.cutout) {
+        final b = feature.bounds;
+        if (b.left <= 0) cutoutLeft = math.max(cutoutLeft, b.right);
+        if (b.top <= 0) cutoutTop = math.max(cutoutTop, b.bottom);
+        if (b.right >= size.width) {
+          cutoutRight = math.max(cutoutRight, size.width - b.left);
+        }
+      }
+    }
+
+    final leftPad = math.max(vp.left, cutoutLeft) + 24;
+    final topPad = math.max(vp.top, cutoutTop) + 24;
+    final rightPad = math.max(vp.right, cutoutRight) + 24;
+    final bottomPad = vp.bottom + 24;
+
     return PopScope(
       canPop: false, // 뒤로가기 버튼 막기
       child: Scaffold(
-        appBar: CustomTitleBar(title: '길찾기'),
-        body: SafeArea(
-          bottom: false,
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
-            child: Column(
-              children: [
-                Expanded(
-                  child: SingleChildScrollView(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        NavigationOverviewCard(
+        body: Padding(
+          padding: EdgeInsets.fromLTRB(leftPad, topPad, rightPad, 0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: SingleChildScrollView(
+                        child: NavigationOverviewCard(
                           distance: 850,
                           time: 12,
                           status: RouteStatus.safe,
                         ),
-                        const SizedBox(height: 20),
-                        NavigationStepCard(
-                          direction: DirectionType.straight,
-                          instruction: '100m 앞에서 우회전하세요.',
-                          distance: 100,
-                        ),
-                        const SizedBox(height: 20),
-                        NavigationVoiceGuideCard(
-                          voiceGuide: '50미터 앞 오른쪽에 킥보드가 감지되었습니다.',
-                        ),
-                      ],
+                      ),
                     ),
-                  ),
-                ),
-                SafeArea(
-                  child: Padding(
-                    padding: const EdgeInsets.only(top: 16, bottom: 24),
-                    child: ActionButton(
-                      label: '안내 중지',
-                      icon: Icons.stop_circle_outlined,
-                      backgroundColor: ColorCollection.red,
-                      onTap: () => Navigator.pop(context),
+                    Padding(
+                      padding: EdgeInsets.only(top: 16, bottom: bottomPad),
+                      child: ActionButton(
+                        label: '안내 중지',
+                        icon: Icons.stop_circle_outlined,
+                        backgroundColor: ColorCollection.red,
+                        onTap: () {
+                          SystemChrome.setPreferredOrientations([
+                            DeviceOrientation.portraitUp,
+                            DeviceOrientation.portraitDown,
+                          ]);
+                          Navigator.pop(context);
+                        },
+                      ),
                     ),
-                  ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+              const SizedBox(width: 24),
+              Expanded(
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: SingleChildScrollView(
+                        padding: const EdgeInsets.symmetric(horizontal: 2),
+                        child: Column(
+                          children: [
+                            NavigationStepCard(
+                              direction: DirectionType.straight,
+                              instruction: '100m 앞에서 우회전하세요.',
+                              distance: 100,
+                            ),
+                            const SizedBox(height: 20),
+                            NavigationVoiceGuideCard(
+                              voiceGuide: '50미터 앞 오른쪽에 킥보드가 감지되었습니다.',
+                            ),
+                            const SizedBox(height: 20),
+                            NavigationVoiceGuideCard(
+                              voiceGuide: '50미터 앞 오른쪽에 킥보드가 감지되었습니다.',
+                            ),
+                            SizedBox(height: bottomPad),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/frontend/lib/features/navigation/navigation_overview_card.dart
+++ b/frontend/lib/features/navigation/navigation_overview_card.dart
@@ -89,43 +89,50 @@ class NavigationOverviewCard extends StatelessWidget {
             Divider(color: ColorCollection.point, thickness: 2),
             const SizedBox(height: 15),
             Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
-                Column(
-                  children: [
-                    Text(
-                      _formatTime(time),
-                      style: AppTextStyles.title2.copyWith(
-                        color: ColorCollection.point,
-                        fontSize: 20,
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        _formatTime(time),
+                        style: AppTextStyles.title2.copyWith(
+                          color: ColorCollection.point,
+                          fontSize: 20,
+                        ),
+                        overflow: TextOverflow.ellipsis,
                       ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '남은 시간',
-                      style: AppTextStyles.labelBold.copyWith(
-                        color: ColorCollection.point,
+                      const SizedBox(height: 8),
+                      Text(
+                        '남은 시간',
+                        style: AppTextStyles.labelBold.copyWith(
+                          color: ColorCollection.point,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-                Column(
-                  children: [
-                    Text(
-                      _getStatusText(status),
-                      style: AppTextStyles.title2.copyWith(
-                        color: _getStatusColor(status),
-                        fontSize: 20,
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        _getStatusText(status),
+                        style: AppTextStyles.title2.copyWith(
+                          color: _getStatusColor(status),
+                          fontSize: 20,
+                        ),
+                        overflow: TextOverflow.ellipsis,
                       ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '경로 상태',
-                      style: AppTextStyles.labelBold.copyWith(
-                        color: ColorCollection.point,
+                      const SizedBox(height: 8),
+                      Text(
+                        '경로 상태',
+                        style: AppTextStyles.labelBold.copyWith(
+                          color: ColorCollection.point,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
## 📎 Issue 번호
#7 

## 📄 작업 내용 요약
 - `navigation_ing_screen` AppBar 제거 후 발생한 레이아웃 문제 수정                                                                                                                                   
    - 왼쪽 `NavigationOverviewCard`와 오른쪽 `NavigationStepCard` 시작 위치 불일치 수정 (`Row`에 `crossAxisAlignment: CrossAxisAlignment.start` 적용)
    - 가로 모드에서 세로 오버플로우 수정 — 양쪽 컬럼 모두 `Column > Expanded > SingleChildScrollView` 구조로 변경
    - `DottedBorder` 좌우 테두리가 얇아 보이는 현상 수정 — 스크롤 활성화 시 `clipRect`가 stroke를 잘라내는 문제로, `ScrollView`에 `horizontal: 2` padding 추가
- `ActionButton` 텍스트 가로 오버플로우 수정                                                                                                                                                           
    - 좁은 컬럼 너비에서 아이콘 + 텍스트가 2.2px 초과하는 RenderFlex overflow 수정                                                                                                                       
    - `Text`를 `Flexible`로 감싸 가용 너비에 맞게 줄바꿈 처리, `textAlign: center` 추가                                                                                                                  - `NavigationOverviewCard` 하단 Row 레이아웃 개선                                                                                                                                                      
    - `mainAxisAlignment: spaceEvenly` 제거 후 각 Column을 `Expanded`로 감싸 균등 너비 분배                                                                                                              
    - 텍스트에 `overflow: TextOverflow.ellipsis` 추가 

## 📸 스크린샷 (UI 변경 시 작성, 없으면 삭제)
<img width="2340" height="1080" alt="Screenshot_20260416_144029" src="https://github.com/user-attachments/assets/0fd83fd1-7bd9-41b2-a87c-6002bc806cdd" />


## ✅ 체크리스트

- [x] 안내 시작시 가로 화면으로 정상 전환된다.
- [x] 안내 중지시 세로 화면으로 정상 전환된다.
- [x] 오버플로우가 발생하지 않는다.

## 💬 리뷰 요청 사항
 `ActionButton`은 공용 위젯이므로, `Flexible` 추가로 인한 다른 화면에서의 버튼 텍스트 줄바꿈 여부 확인 부탁드립니다.