### PR TITLE
[FIX] 현재 위치 로딩 실패 및 길안내 화면 route null 버그 수정

### DIFF
--- a/frontend/lib/routes/app_router.dart
+++ b/frontend/lib/routes/app_router.dart
@@ -71,7 +71,10 @@ class AppRouter {
       case savedplace:
         return MaterialPageRoute(builder: (_) => const SavedPlaceScreen());
       case navigationing:
-        return MaterialPageRoute(builder: (_) => const NavigationIngScreen());
+        return MaterialPageRoute(
+          settings: settings,
+          builder: (_) => const NavigationIngScreen(),
+        );
       case addplace:
         return MaterialPageRoute(builder: (_) => const AddPlaceScreen());
       case appinfo:

--- a/frontend/lib/service/place_service.dart
+++ b/frontend/lib/service/place_service.dart
@@ -26,7 +26,7 @@ class PlaceService {
         final data = jsonDecode(response.body);
 
         if (data['success']) {
-          return data['data']['roadAddress'];
+          return data['data']['roadAddress'] ?? data['data']['address'];
         }
       }
 


### PR DESCRIPTION
## 📎 Issue 번호
Closes #41, Closes #42

## 📄 작업 내용 요약
- reverseGeocode 응답에서 roadAddress가 null인 경우 address 필드로 폴백                                                                                                                                   
- navigationing 라우트에 settings 미전달로 Navigator arguments가 유실되던 버그 수정 

## ✅ 체크리스트

- [x] 도로명 주소가 없는 위치에서 현재 위치가 정상 표시되는지 확인
- [x] 안내 시작 후 NavigationIngScreen에서 경로 카드가 정상 표시되는지 확인
