### PR TITLE
[FEAT] 길찾기 API 연동 및 실시간 step 안내 구현

### DIFF
--- a/frontend/lib/common/widgets/route_debug_overlay.dart
+++ b/frontend/lib/common/widgets/route_debug_overlay.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:safepath/features/navigation/navigation_step_card.dart';
+import 'package:safepath/models/route_result.dart';
+
+/// 디버그 전용 경로 안내 PiP 오버레이
+///
+/// kDebugMode일 때만 렌더링됨 — release 빌드에서는 SizedBox.shrink()로 대체
+///
+/// 사용 예시:
+///   Stack(
+///     children: [
+///       ... 본 화면 위젯 ...
+///       RouteDebugOverlay(
+///         pointSteps: _pointSteps,
+///         currentStepIndex: _currentStepIndex,
+///         distanceToStep: _debugDistance,
+///         outsideThreshold: _hasBeenOutsideThreshold,
+///         threshold: _arrivalThresholdMeters,
+///       ),
+///     ],
+///   )
+class RouteDebugOverlay extends StatefulWidget {
+  final List<RouteStep> pointSteps;
+  final int currentStepIndex;
+  final double? distanceToStep;
+  final bool outsideThreshold;
+  final double threshold;
+
+  const RouteDebugOverlay({
+    super.key,
+    required this.pointSteps,
+    required this.currentStepIndex,
+    required this.distanceToStep,
+    required this.outsideThreshold,
+    required this.threshold,
+  });
+
+  @override
+  State<RouteDebugOverlay> createState() => _RouteDebugOverlayState();
+}
+
+class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
+  bool _visible = true;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+
+    final vp = MediaQuery.of(context).viewPadding;
+
+    if (!_visible) {
+      return Positioned(
+        right: 8 + vp.right,
+        top: 8 + vp.top,
+        child: GestureDetector(
+          onTap: () => setState(() => _visible = true),
+          child: Container(
+            padding: const EdgeInsets.all(6),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.6),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: const Icon(Icons.navigation, color: Colors.white, size: 18),
+          ),
+        ),
+      );
+    }
+
+    return Positioned(
+      right: 8 + vp.right,
+      top: 8 + vp.top,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 헤더 (닫기 버튼)
+          GestureDetector(
+            onTap: () => setState(() => _visible = false),
+            child: Container(
+              width: 210,
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.85),
+                borderRadius: const BorderRadius.only(
+                  topLeft: Radius.circular(8),
+                  topRight: Radius.circular(8),
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    'ROUTE DEBUG',
+                    style: TextStyle(
+                      color: Colors.yellow,
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      Text(
+                        'Step ${widget.currentStepIndex}/${widget.pointSteps.length}',
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 10,
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      const Icon(Icons.close, color: Colors.white, size: 14),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // step 목록
+          Container(
+            width: 210,
+            constraints: const BoxConstraints(maxHeight: 260),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.75),
+              borderRadius: const BorderRadius.only(
+                bottomLeft: Radius.circular(8),
+                bottomRight: Radius.circular(8),
+              ),
+            ),
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(6),
+              child: Column(
+                children: [
+                  for (int i = 0; i < widget.pointSteps.length; i++)
+                    _StepDebugCard(
+                      step: widget.pointSteps[i],
+                      isCurrent: i == widget.currentStepIndex,
+                      distanceToStep: i == widget.currentStepIndex
+                          ? widget.distanceToStep
+                          : null,
+                      outsideThreshold: i == widget.currentStepIndex
+                          ? widget.outsideThreshold
+                          : null,
+                      threshold: widget.threshold,
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StepDebugCard extends StatelessWidget {
+  final RouteStep step;
+  final bool isCurrent;
+  final double? distanceToStep;
+  final bool? outsideThreshold;
+  final double threshold;
+
+  const _StepDebugCard({
+    required this.step,
+    required this.isCurrent,
+    required this.distanceToStep,
+    required this.outsideThreshold,
+    required this.threshold,
+  });
+
+  DirectionType _turnTypeToDirection(int? turnType) {
+    switch (turnType) {
+      case 12:
+      case 16:
+      case 17:
+        return DirectionType.left;
+      case 13:
+      case 18:
+      case 19:
+        return DirectionType.right;
+      case 211:
+      case 212:
+      case 213:
+      case 214:
+      case 215:
+      case 216:
+      case 217:
+      case 125:
+      case 126:
+        return DirectionType.crosswalk;
+      default:
+        return DirectionType.straight;
+    }
+  }
+
+  IconData _directionIcon(DirectionType d) {
+    switch (d) {
+      case DirectionType.left:
+        return Icons.turn_left;
+      case DirectionType.right:
+        return Icons.turn_right;
+      case DirectionType.crosswalk:
+        return Icons.directions_walk;
+      case DirectionType.straight:
+        return Icons.arrow_upward;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final direction = _turnTypeToDirection(step.turnType);
+    final isClose =
+        distanceToStep != null && distanceToStep! < threshold;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 4),
+      padding: const EdgeInsets.all(6),
+      decoration: BoxDecoration(
+        color: isCurrent
+            ? Colors.green.withValues(alpha: 0.15)
+            : Colors.white.withValues(alpha: 0.05),
+        border: Border.all(
+          color: isCurrent ? Colors.green : Colors.white24,
+          width: isCurrent ? 1.5 : 0.5,
+        ),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                _directionIcon(direction),
+                color: isCurrent ? Colors.green : Colors.white38,
+                size: 14,
+              ),
+              const SizedBox(width: 4),
+              Expanded(
+                child: Text(
+                  step.description ?? '',
+                  style: TextStyle(
+                    color: isCurrent ? Colors.white : Colors.white54,
+                    fontSize: 9,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+
+          // 현재 step만 실시간 거리 표시
+          if (isCurrent && distanceToStep != null) ...[
+            const SizedBox(height: 4),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '${distanceToStep!.toStringAsFixed(1)}m',
+                  style: TextStyle(
+                    color: isClose ? Colors.green : Colors.orange,
+                    fontSize: 11,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                Text(
+                  outsideThreshold == true ? '진행 중' : '대기 중',
+                  style: TextStyle(
+                    color: outsideThreshold == true
+                        ? Colors.green
+                        : Colors.orange,
+                    fontSize: 9,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -1,10 +1,14 @@
+import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/common/widgets/action_button_widget.dart';
+import 'package:safepath/common/widgets/route_debug_overlay.dart';
 import 'package:safepath/features/navigation/navigation_step_card.dart';
-import 'package:safepath/features/navigation/navigation_voiceguide_card.dart';
 import 'package:safepath/features/navigation/navigation_overview_card.dart';
+import 'package:safepath/models/route_result.dart';
 import 'dart:ui' show DisplayFeatureType;
 import 'package:flutter/services.dart';
 
@@ -16,10 +20,19 @@ class NavigationIngScreen extends StatefulWidget {
 }
 
 class _NavigationIngScreenState extends State<NavigationIngScreen> {
+  RouteResult? _route;
+  List<RouteStep> _pointSteps = [];
+  int _currentStepIndex = 0;
+  StreamSubscription<Position>? _positionSub;
+  bool _routeLoaded = false;
+
+  static const double _arrivalThresholdMeters = 10;
+  bool _hasBeenOutsideThreshold = false;
+  double? _debugDistance;
+
   @override
   void initState() {
     super.initState();
-    // 가로 모드로 고정
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.landscapeLeft,
       DeviceOrientation.landscapeRight,
@@ -27,8 +40,63 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_routeLoaded) {
+      _route = ModalRoute.of(context)?.settings.arguments as RouteResult?;
+      if (_route != null) {
+        _pointSteps = _route!.steps
+            .where(
+              (s) =>
+                  s.type == 'POINT' &&
+                  s.pointType != 'SP' &&
+                  s.pointType != 'EP',
+            )
+            .toList();
+        _startLocationTracking();
+        _routeLoaded = true;
+      }
+    }
+  }
+
+  void _startLocationTracking() {
+    _positionSub = Geolocator.getPositionStream(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.high,
+        distanceFilter: 5,
+      ),
+    ).listen(_onPositionUpdate);
+  }
+
+  void _onPositionUpdate(Position position) {
+    if (_pointSteps.isEmpty || _currentStepIndex >= _pointSteps.length) return;
+
+    final step = _pointSteps[_currentStepIndex];
+    if (step.latitude == null || step.longitude == null) return;
+
+    final distance = Geolocator.distanceBetween(
+      position.latitude,
+      position.longitude,
+      step.latitude!,
+      step.longitude!,
+    );
+
+    setState(() => _debugDistance = distance);
+
+    if (distance >= _arrivalThresholdMeters) {
+      _hasBeenOutsideThreshold = true;
+    } else if (_hasBeenOutsideThreshold) {
+      // 멀어졌다가 다시 가까워질 때만 다음 step으로 진행
+      setState(() {
+        _currentStepIndex++;
+        _hasBeenOutsideThreshold = false;
+      });
+    }
+  }
+
+  @override
   void dispose() {
-    // 다시 세로 모드 허용
+    _positionSub?.cancel();
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
@@ -42,7 +110,6 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     final vp = mq.viewPadding;
     final size = mq.size;
 
-    // viewPadding이 0인 기기에서도 displayFeatures로 실제 카메라 cutout 영역을 감지
     double cutoutLeft = 0, cutoutTop = 0, cutoutRight = 0;
     for (final feature in mq.displayFeatures) {
       if (feature.type == DisplayFeatureType.cutout) {
@@ -60,79 +127,125 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     final rightPad = math.max(vp.right, cutoutRight) + 24;
     final bottomPad = vp.bottom + 24;
 
+    final hasCurrentStep =
+        _pointSteps.isNotEmpty && _currentStepIndex < _pointSteps.length;
+    final currentStep = hasCurrentStep ? _pointSteps[_currentStepIndex] : null;
+
     return PopScope(
-      canPop: false, // 뒤로가기 버튼 막기
+      canPop: false,
       child: Scaffold(
-        body: Padding(
-          padding: EdgeInsets.fromLTRB(leftPad, topPad, rightPad, 0),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Expanded(
-                      child: SingleChildScrollView(
-                        child: NavigationOverviewCard(
-                          distance: 850,
-                          time: 12,
-                          status: RouteStatus.safe,
+        body: Stack(
+          children: [
+            Padding(
+              padding: EdgeInsets.fromLTRB(leftPad, topPad, rightPad, 0),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Expanded(
+                          child: NavigationOverviewCard(
+                            distance: _route?.totalDistance ?? 0,
+                            time: _route != null
+                                ? (_route!.totalTime / 60).ceil()
+                                : 0,
+                            status: RouteStatus.safe,
+                          ),
                         ),
-                      ),
-                    ),
-                    Padding(
-                      padding: EdgeInsets.only(top: 16, bottom: bottomPad),
-                      child: ActionButton(
-                        label: '안내 중지',
-                        icon: Icons.stop_circle_outlined,
-                        backgroundColor: ColorCollection.red,
-                        onTap: () {
-                          SystemChrome.setPreferredOrientations([
-                            DeviceOrientation.portraitUp,
-                            DeviceOrientation.portraitDown,
-                          ]);
-                          Navigator.pop(context);
-                        },
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(width: 24),
-              Expanded(
-                child: Column(
-                  children: [
-                    Expanded(
-                      child: SingleChildScrollView(
-                        padding: const EdgeInsets.symmetric(horizontal: 2),
-                        child: Column(
-                          children: [
-                            NavigationStepCard(
-                              direction: DirectionType.straight,
-                              instruction: '100m 앞에서 우회전하세요.',
-                              distance: 100,
-                            ),
-                            const SizedBox(height: 20),
-                            NavigationVoiceGuideCard(
-                              voiceGuide: '50미터 앞 오른쪽에 킥보드가 감지되었습니다.',
-                            ),
-                            const SizedBox(height: 20),
-                            NavigationVoiceGuideCard(
-                              voiceGuide: '50미터 앞 오른쪽에 킥보드가 감지되었습니다.',
-                            ),
-                            SizedBox(height: bottomPad),
-                          ],
+                        Padding(
+                          padding: EdgeInsets.only(top: 16, bottom: bottomPad),
+                          child: ActionButton(
+                            label: '안내 중지',
+                            icon: Icons.stop_circle_outlined,
+                            backgroundColor: ColorCollection.red,
+                            onTap: () {
+                              SystemChrome.setPreferredOrientations([
+                                DeviceOrientation.portraitUp,
+                                DeviceOrientation.portraitDown,
+                              ]);
+                              Navigator.pop(context);
+                            },
+                          ),
                         ),
-                      ),
+                      ],
                     ),
-                  ],
-                ),
+                  ),
+                  const SizedBox(width: 24),
+                  Expanded(
+                    child: Column(
+                      children: [
+                        Expanded(
+                          child: SingleChildScrollView(
+                            padding: const EdgeInsets.symmetric(horizontal: 2),
+                            child: Column(
+                              children: [
+                                if (currentStep != null)
+                                  NavigationStepCard(
+                                    direction: _turnTypeToDirection(
+                                      currentStep.turnType,
+                                    ),
+                                    instruction: currentStep.description ?? '',
+                                    distance: _route?.totalDistance ?? 0,
+                                  )
+                                else if (_route != null)
+                                  // 모든 step 완료
+                                  Center(
+                                    child: Text(
+                                      '목적지에 도착했습니다!',
+                                      style: AppTextStyles.labelRegular
+                                          .copyWith(
+                                            color: ColorCollection.point,
+                                          ),
+                                    ),
+                                  ),
+                                SizedBox(height: bottomPad),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+            RouteDebugOverlay(
+              pointSteps: _pointSteps,
+              currentStepIndex: _currentStepIndex,
+              distanceToStep: _debugDistance,
+              outsideThreshold: _hasBeenOutsideThreshold,
+              threshold: _arrivalThresholdMeters,
+            ),
+          ],
         ),
       ),
     );
+  }
+
+  DirectionType _turnTypeToDirection(int? turnType) {
+    switch (turnType) {
+      case 12:
+      case 16:
+      case 17:
+        return DirectionType.left;
+      case 13:
+      case 18:
+      case 19:
+        return DirectionType.right;
+      case 211:
+      case 212:
+      case 213:
+      case 214:
+      case 215:
+      case 216:
+      case 217:
+      case 125: // 육교
+      case 126: // 지하보도
+        return DirectionType.crosswalk;
+      default: // 11 직진, 233 직진 임시, 14 유턴, 기타
+        return DirectionType.straight;
+    }
   }
 }

--- a/frontend/lib/features/navigation/navigation_overview_card.dart
+++ b/frontend/lib/features/navigation/navigation_overview_card.dart
@@ -70,6 +70,7 @@ class NavigationOverviewCard extends StatelessWidget {
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Text(
               _formatDistance(distance),
@@ -80,14 +81,14 @@ class NavigationOverviewCard extends StatelessWidget {
             ),
             const SizedBox(height: 4),
             Text(
-              '남은 거리',
+              '총 거리',
               style: AppTextStyles.labelBold.copyWith(
                 color: ColorCollection.point,
               ),
             ),
-            const SizedBox(height: 15),
+            const SizedBox(height: 8),
             Divider(color: ColorCollection.point, thickness: 2),
-            const SizedBox(height: 15),
+            const SizedBox(height: 8),
             Row(
               children: [
                 Expanded(
@@ -104,7 +105,7 @@ class NavigationOverviewCard extends StatelessWidget {
                       ),
                       const SizedBox(height: 8),
                       Text(
-                        '남은 시간',
+                        '총 소요 시간',
                         style: AppTextStyles.labelBold.copyWith(
                           color: ColorCollection.point,
                         ),

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -14,6 +14,7 @@ import 'package:safepath/routes/app_router.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
 import 'package:geolocator/geolocator.dart';
 import 'package:safepath/service/place_service.dart';
+import 'package:safepath/service/navigation_service.dart';
 
 class NavigationScreen extends StatefulWidget {
   const NavigationScreen({super.key});
@@ -33,7 +34,11 @@ class _NavigationScreenState extends State<NavigationScreen> {
   /// 위치 변수
   String currentLocation = "현재 위치 불러오는 중...";
   String selectedLocation = "목적지를 선택해 주세요.";
+  double? _selectedLat;
+  double? _selectedLng;
+  String _selectedName = '';
   List<Map<String, dynamic>> searchResults = [];
+  bool _showSearchOverlay = false;
   bool _hasNext = false;
   int _currentPage = 1;
   bool _isLoadingMore = false;
@@ -55,7 +60,6 @@ class _NavigationScreenState extends State<NavigationScreen> {
       if (_debounce?.isActive ?? false) _debounce!.cancel();
 
       _debounce = Timer(const Duration(milliseconds: 300), () {
-        // 🔥 선택 직후에는 검색 다시 안 하도록 방지
         if (_isSelecting) return;
         searchPlaces();
       });
@@ -142,16 +146,52 @@ class _NavigationScreenState extends State<NavigationScreen> {
   }
 
   /// 길찾기 시작 함수
-  void startNavigation() {
-    // 키보드 먼저 닫기
+  void startNavigation() async {
+    if (_currentPosition == null ||
+        _selectedLat == null ||
+        _selectedLng == null) {
+      return;
+    }
+
     FocusManager.instance.primaryFocus?.unfocus();
 
-    Navigator.pushNamed(context, AppRouter.navigationing).then((_) {
-      // 돌아왔을 때 입력값 초기화
+    setState(() => isLoading = true);
+
+    try {
+      final result = await NavigationService.getRoute(
+        startX: _currentPosition!.longitude,
+        startY: _currentPosition!.latitude,
+        endX: _selectedLng!,
+        endY: _selectedLat!,
+        startName: currentLocation,
+        endName: _selectedName,
+      );
+
+      if (!mounted) return;
+
+      await Navigator.pushNamed(
+        context,
+        AppRouter.navigationing,
+        arguments: result,
+      );
+
+      // 돌아왔을 때 입력값 초기화 및 위치 갱신
       destinationController.clear();
       FocusManager.instance.primaryFocus?.unfocus();
-      selectedLocation = "목적지를 선택해 주세요.";
-    });
+      setState(() {
+        selectedLocation = "목적지를 선택해 주세요.";
+        _selectedLat = null;
+        _selectedLng = null;
+        _selectedName = '';
+        currentLocation = "현재 위치 불러오는 중...";
+      });
+      initCurrentPosition();
+      loadLocation();
+    } catch (e) {
+      debugPrint('🔴 [Navigation] 길찾기 오류: $e');
+    } finally {
+      if (mounted) setState(() => isLoading = false);
+    }
   }
 
   /// 현재 위치 위도,경도 가져오기
@@ -210,6 +250,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
     if (destinationController.text.trim().isEmpty) {
       setState(() {
         searchResults.clear();
+        _showSearchOverlay = false;
         _hasNext = false;
         _currentPage = 1;
       });
@@ -223,6 +264,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
 
       setState(() {
         isLoading = true;
+        _showSearchOverlay = true;
         _currentPage = 1;
       });
 
@@ -291,14 +333,14 @@ class _NavigationScreenState extends State<NavigationScreen> {
                       controller: destinationController,
                       onClear: () {
                         FocusManager.instance.primaryFocus?.unfocus();
-
-                        // 검색 중 상태 초기화
                         _isSelecting = false;
+                        _debounce?.cancel();
 
                         setState(() {
                           destinationController.clear();
                           selectedLocation = "목적지를 선택해 주세요.";
                           searchResults.clear();
+                          _showSearchOverlay = false;
                           isLoading = false;
                           _hasNext = false;
                           _currentPage = 1;
@@ -352,15 +394,17 @@ class _NavigationScreenState extends State<NavigationScreen> {
                             if (place != null) {
                               FocusManager.instance.primaryFocus?.unfocus();
                               _isSelecting = true;
+                              final p = place as SavedPlace;
                               setState(() {
-                                destinationController.text =
-                                    (place as dynamic).label;
-                                selectedLocation = (place as dynamic).location;
+                                destinationController.text = p.label;
+                                selectedLocation = p.location;
+                                _selectedName = p.label;
+                                _selectedLat = p.lat;
+                                _selectedLng = p.lng;
+                                _showSearchOverlay = false;
                               });
-                              Future.delayed(
-                                const Duration(milliseconds: 300),
-                                () => _isSelecting = false,
-                              );
+                              _debounce?.cancel();
+                              _isSelecting = false;
                             }
                           },
                         ),
@@ -393,11 +437,13 @@ class _NavigationScreenState extends State<NavigationScreen> {
                               setState(() {
                                 destinationController.text = place.label;
                                 selectedLocation = place.location;
+                                _selectedName = place.label;
+                                _selectedLat = place.lat;
+                                _selectedLng = place.lng;
+                                _showSearchOverlay = false;
                               });
-                              Future.delayed(
-                                const Duration(milliseconds: 300),
-                                () => _isSelecting = false,
-                              );
+                              _debounce?.cancel();
+                              _isSelecting = false;
                             },
                           ),
                         );
@@ -454,11 +500,15 @@ class _NavigationScreenState extends State<NavigationScreen> {
                                 destinationController.text =
                                     place['name'] as String;
                                 selectedLocation = place['address'] as String;
+                                _selectedName = place['name'] as String;
+                                _selectedLat = (place['lat'] as num?)
+                                    ?.toDouble();
+                                _selectedLng = (place['lng'] as num?)
+                                    ?.toDouble();
+                                _showSearchOverlay = false;
                               });
-                              Future.delayed(
-                                const Duration(milliseconds: 300),
-                                () => _isSelecting = false,
-                              );
+                              _debounce?.cancel();
+                              _isSelecting = false;
                             },
                           ),
                         );
@@ -468,7 +518,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
               ),
 
               /// 검색 결과 overlay
-              if (destinationController.text.trim().isNotEmpty && !_isSelecting)
+              if (_showSearchOverlay && !_isSelecting)
                 Positioned(
                   top: 60,
                   left: 0,
@@ -484,7 +534,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
                     child: Container(color: Colors.transparent),
                   ),
                 ),
-              if (destinationController.text.trim().isNotEmpty && !_isSelecting)
+              if (_showSearchOverlay && !_isSelecting)
                 Positioned(
                   top: 50,
                   left: 0,
@@ -498,26 +548,24 @@ class _NavigationScreenState extends State<NavigationScreen> {
                           onLoadMore: _loadMorePlaces,
                           onTap: (item) {
                             FocusManager.instance.primaryFocus?.unfocus();
-
                             _isSelecting = true;
 
                             setState(() {
                               destinationController.text = item['name'];
                               selectedLocation = item['roadAddress'];
+                              _selectedName = item['name'] as String;
+                              _selectedLat = item['latitude'] as double?;
+                              _selectedLng = item['longitude'] as double?;
                               searchResults.clear();
+                              _showSearchOverlay = false;
                             });
+
+                            _debounce?.cancel();
+                            _isSelecting = false;
 
                             PlaceService.getPlaceDetail(
                               placeId: item['id'],
                             ).then((_) => _loadRecentPlaces());
-
-                            // 잠깐 후 다시 검색 가능하도록
-                            Future.delayed(
-                              const Duration(milliseconds: 300),
-                              () {
-                                _isSelecting = false;
-                              },
-                            );
                           },
                         )
                       : Container(

--- a/frontend/lib/models/route_result.dart
+++ b/frontend/lib/models/route_result.dart
@@ -1,0 +1,74 @@
+class RouteResult {
+  final int totalDistance; // 총 거리 (미터)
+  final int totalTime; // 총 소요 시간 (초)
+  final List<RouteStep> steps;
+
+  const RouteResult({
+    required this.totalDistance,
+    required this.totalTime,
+    required this.steps,
+  });
+
+  factory RouteResult.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>;
+    return RouteResult(
+      totalDistance: data['totalDistance'] as int,
+      totalTime: data['totalTime'] as int,
+      steps: (data['steps'] as List)
+          .map((s) => RouteStep.fromJson(s as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+class RouteStep {
+  final String type; // "POINT" or "LINE"
+
+  // POINT 전용
+  final double? latitude;
+  final double? longitude;
+  final String? description;
+  final int? turnType;
+  final String? pointType; // "SP"=출발, "EP"=도착
+
+  // LINE 전용
+  final List<LatLng>? path;
+
+  const RouteStep({
+    required this.type,
+    this.latitude,
+    this.longitude,
+    this.description,
+    this.turnType,
+    this.pointType,
+    this.path,
+  });
+
+  factory RouteStep.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String;
+    if (type == 'LINE') {
+      final pathList = (json['path'] as List)
+          .map((p) => LatLng(
+                latitude: (p['latitude'] as num).toDouble(),
+                longitude: (p['longitude'] as num).toDouble(),
+              ))
+          .toList();
+      return RouteStep(type: type, path: pathList);
+    }
+    return RouteStep(
+      type: type,
+      latitude: (json['latitude'] as num?)?.toDouble(),
+      longitude: (json['longitude'] as num?)?.toDouble(),
+      description: json['description'] as String?,
+      turnType: json['turnType'] as int?,
+      pointType: json['pointType'] as String?,
+    );
+  }
+}
+
+class LatLng {
+  final double latitude;
+  final double longitude;
+
+  const LatLng({required this.latitude, required this.longitude});
+}

--- a/frontend/lib/models/saved_place.dart
+++ b/frontend/lib/models/saved_place.dart
@@ -6,12 +6,16 @@ class SavedPlace {
   final String label; // 장소 이름
   final String location; // 주소
   final PlaceCategory category; // 카테고리
+  final double? lat;
+  final double? lng;
 
   const SavedPlace({
     required this.id,
     required this.label,
     required this.location,
     required this.category,
+    this.lat,
+    this.lng,
   });
 
   /// BE 응답 JSON -> Model 변환
@@ -24,6 +28,8 @@ class SavedPlace {
         (e) => e.apiValue == json['category'],
         orElse: () => PlaceCategory.etc,
       ),
+      lat: (json['lat'] as num?)?.toDouble(),
+      lng: (json['lng'] as num?)?.toDouble(),
     );
   }
 

--- a/frontend/lib/service/navigation_service.dart
+++ b/frontend/lib/service/navigation_service.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'package:flutter/cupertino.dart';
+import 'package:http/http.dart' as http;
+import 'package:safepath/models/route_result.dart';
+import 'package:safepath/service/token_storage.dart';
+
+class NavigationService {
+  static const String _baseUrl = String.fromEnvironment('BASE_URL');
+
+  /// 길찾기 API
+  static Future<RouteResult> getRoute({
+    required double startX,
+    required double startY,
+    required double endX,
+    required double endY,
+    required String startName,
+    required String endName,
+  }) async {
+    final uri = Uri.parse('$_baseUrl/api/navigation/routes');
+    final body = jsonEncode({
+      'startX': startX.toString(),
+      'startY': startY.toString(),
+      'endX': endX.toString(),
+      'endY': endY.toString(),
+      'startName': startName,
+      'endName': endName,
+    });
+
+    final token = await TokenStorage().accessToken;
+
+    debugPrint('🟡 [Navigation] 길찾기 요청: POST $uri');
+    debugPrint('📤 body: $body');
+
+    final response = await http.post(
+      uri,
+      headers: {
+        'Content-Type': 'application/json',
+        if (token != null) 'Authorization': 'Bearer $token',
+      },
+      body: body,
+    );
+
+    debugPrint('📥 statusCode: ${response.statusCode}');
+    debugPrint('📥 body: ${response.body}');
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      if (data['success'] == true) {
+        return RouteResult.fromJson(data);
+      }
+    }
+
+    throw Exception('길찾기 API 실패 (${response.statusCode})');
+  }
+}


### PR DESCRIPTION
## 📎 Issue 번호
#7 #8

## 📄 작업 내용 요약
- POST /api/navigation/routes 연동, 경로 결과를 NavigationIngScreen으로 전달
- 실시간 GPS 기반 step 자동 진행 길안내 화면 구현                                                                                                                                                         
- 디버그용 경로 PiP 오버레이 추가                                                                                                                                                                         
- 검색 오버레이 race condition 수정 

## 📄 변경 파일
lib/models/route_result.dart (신규)                                                                                                                                                                   
- RouteResult, RouteStep, LatLng 모델 정의
 
lib/models/saved_place.dart
- lat, lng 좌표 필드 추가 및 fromJSON 파싱 추가
 
lib/service/navigation_service.dart (신규)
  - POST /api/navigation/routes 호출
  - startX/Y, endX/Y, startName, endName 파라미터
  - 응답을 RouteResult로 파싱하여 반환
  
lib/features/navigation/navigation_screen.dart
  - _selectedLat/Lng/Name 필드 추가, 검색·저장·최근 장소 선택 시 좌표 저장                                                                                                                                  
  - startNavigation(): getRoute() 호출 후 RouteResult를 arguments로 전달                                                                                                                                    
  - _showSearchOverlay 플래그 도입으로 장소 선택 후 "검색 결과가 없습니다"
    잔존 현상 수정                                                                                                                                                                                          
  - debounce 타이머와 _isSelecting 간 race condition 수정
    (Future.delayed → _debounce?.cancel() 즉시 처리)

lib/features/navigation/navigation_ing_screen.dart
  - ModalRoute arguments에서 RouteResult 수신                                                                                                                                                               
  - type=POINT, pointType SP/EP 제외 step 필터링
  - Geolocator.getPositionStream(distanceFilter: 5) 실시간 위치 추적
  - 10m 임계값 기반 step 자동 진행                                                                                                                                                                          
  - _hasBeenOutsideThreshold 플래그로 진입 시 즉시 step 진행 방지
  - 가로 모드 강제 및 노치/OS 네비게이션 바 안전 영역 padding 계산
  
lib/features/navigation/navigation_overview_card.dart                                                                                                                                                 
  - SingleChildScrollView 제거, 남은 공간 꽉 채움
  - SizedBox height 조정으로 RenderFlex overflow 수정
  
lib/common/widgets/route_debug_overlay.dart (신규)
  - kDebugMode 가드 (release 빌드 미노출)                                                                                                                                                                   
  - 전체 step 카드 목록, 현재 step 초록 테두리 강조
  - 실시간 거리 및 진행 중/대기 중 상태 표시                                                                                                                                                                
  - 토글 버튼으로 접기/펼치기                                                                                                                                                                               
  - MediaQuery.viewPadding 적용으로 OS 네비게이션 바 겹침 방지
  
## 📸 스크린샷 (UI 변경 시 작성, 없으면 삭제)
<img width="2340" height="1080" alt="KakaoTalk_Photo_2026-04-24-18-09-02 001" src="https://github.com/user-attachments/assets/18cc0981-b9ec-4a29-a462-ab6fdb51a263" />
<img width="2340" height="1080" alt="KakaoTalk_Photo_2026-04-24-18-09-02 002" src="https://github.com/user-attachments/assets/b21e6416-a428-43f6-bb36-b739371cecb7" />

## ✅ 체크리스트
- [x] 장소 검색 후 선택 시 검색 오버레이가 즉시 닫히는지 확인
- [x] 안내 시작 후 경로 카드 및 개요 카드 정상 표시 확인                                                                                                                                                  
- [x] 실외 이동 시 10m 임계값 기준 step 자동 진행 확인  
- [x] 디버그 오버레이 step 목록 및 실시간 거리 표시 확인                                                                                                                                                  
- [x] OS 네비게이션 바와 오버레이 겹침 없는지 확인
