### PR TITLE
[FEAT] 길안내 경로 이탈 감지 및 자동 재탐색 기능 구현

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -9,6 +9,7 @@ import 'package:safepath/common/widgets/route_debug_overlay.dart';
 import 'package:safepath/features/navigation/navigation_step_card.dart';
 import 'package:safepath/features/navigation/navigation_overview_card.dart';
 import 'package:safepath/models/route_result.dart';
+import 'package:safepath/service/navigation_service.dart';
 import 'dart:ui' show DisplayFeatureType;
 import 'package:flutter/services.dart';
 
@@ -22,13 +23,26 @@ class NavigationIngScreen extends StatefulWidget {
 class _NavigationIngScreenState extends State<NavigationIngScreen> {
   RouteResult? _route;
   List<RouteStep> _pointSteps = [];
+  RouteStep? _destinationStep;
+  List<LatLng> _routePath = [];
   int _currentStepIndex = 0;
   StreamSubscription<Position>? _positionSub;
   bool _routeLoaded = false;
 
+  // 목적지 정보 (재탐색 시 사용)
+  double? _endX;
+  double? _endY;
+  String _endName = '';
+
   static const double _arrivalThresholdMeters = 10;
   bool _hasBeenOutsideThreshold = false;
   double? _debugDistance;
+
+  // 경로 이탈 감지
+  static const double _deviationThresholdMeters = 30.0;
+  static const int _deviationCountThreshold = 3;
+  int _deviationCount = 0;
+  bool _isRecalculating = false;
 
   @override
   void initState() {
@@ -43,20 +57,49 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!_routeLoaded) {
-      _route = ModalRoute.of(context)?.settings.arguments as RouteResult?;
+      final args = ModalRoute.of(context)?.settings.arguments;
+      if (args is Map<String, dynamic>) {
+        _route = args['route'] as RouteResult?;
+        _endX = args['endX'] as double?;
+        _endY = args['endY'] as double?;
+        _endName = (args['endName'] as String?) ?? '';
+      } else {
+        _route = args as RouteResult?;
+      }
       if (_route != null) {
-        _pointSteps = _route!.steps
-            .where(
-              (s) =>
-                  s.type == 'POINT' &&
-                  s.pointType != 'SP' &&
-                  s.pointType != 'EP',
-            )
-            .toList();
+        _loadRoute(_route!);
         _startLocationTracking();
         _routeLoaded = true;
       }
     }
+  }
+
+  void _loadRoute(RouteResult route) {
+    _pointSteps = route.steps
+        .where(
+          (s) =>
+              s.type == 'POINT' && s.pointType != 'SP' && s.pointType != 'EP',
+        )
+        .toList();
+    _destinationStep = route.steps
+        .where((s) => s.pointType == 'EP')
+        .firstOrNull;
+    _routePath = route.steps
+        .where((s) => s.type == 'LINE')
+        .expand((s) => s.path ?? <LatLng>[])
+        .toList();
+    debugPrint(
+      '📍 [Nav] 전체 step 수: ${_pointSteps.length}, path 좌표 수: ${_routePath.length}',
+    );
+    for (int i = 0; i < _pointSteps.length; i++) {
+      final s = _pointSteps[i];
+      debugPrint(
+        '  [$i] turnType=${s.turnType} (${s.latitude}, ${s.longitude}) ${s.description}',
+      );
+    }
+    debugPrint(
+      '  [목적지] (${_destinationStep?.latitude}, ${_destinationStep?.longitude})',
+    );
   }
 
   void _startLocationTracking() {
@@ -82,15 +125,83 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     );
 
     setState(() => _debugDistance = distance);
+    debugPrint(
+      '📍 [Nav] step $_currentStepIndex/${_pointSteps.length - 1} | '
+      '남은 거리: ${distance.toStringAsFixed(1)}m | '
+      '${_hasBeenOutsideThreshold ? "진행 중" : "대기 중"} | '
+      '${_pointSteps[_currentStepIndex].description}',
+    );
 
     if (distance >= _arrivalThresholdMeters) {
       _hasBeenOutsideThreshold = true;
     } else if (_hasBeenOutsideThreshold) {
-      // 멀어졌다가 다시 가까워질 때만 다음 step으로 진행
       setState(() {
         _currentStepIndex++;
         _hasBeenOutsideThreshold = false;
       });
+    }
+
+    _checkDeviation(position);
+  }
+
+  void _checkDeviation(Position position) {
+    if (_routePath.isEmpty || _isRecalculating) return;
+
+    double minDist = double.infinity;
+    for (final point in _routePath) {
+      final d = Geolocator.distanceBetween(
+        position.latitude,
+        position.longitude,
+        point.latitude,
+        point.longitude,
+      );
+      if (d < minDist) minDist = d;
+    }
+
+    if (minDist > _deviationThresholdMeters) {
+      _deviationCount++;
+      debugPrint(
+        '⚠️ [Nav] 경로 이탈: ${minDist.toStringAsFixed(1)}m ($_deviationCount/$_deviationCountThreshold회)',
+      );
+      if (_deviationCount >= _deviationCountThreshold) {
+        _recalculateRoute(position);
+      }
+    } else {
+      if (_deviationCount > 0) _deviationCount = 0;
+    }
+  }
+
+  Future<void> _recalculateRoute(Position position) async {
+    if (_isRecalculating || _endX == null || _endY == null) return;
+
+    setState(() => _isRecalculating = true);
+    _deviationCount = 0;
+    debugPrint('🔄 [Nav] 경로 재탐색 시작...');
+
+    try {
+      final result = await NavigationService.getRoute(
+        startX: position.longitude,
+        startY: position.latitude,
+        endX: _endX!,
+        endY: _endY!,
+        startName: '현재 위치',
+        endName: _endName,
+      );
+
+      if (!mounted) return;
+
+      setState(() {
+        _route = result;
+        _currentStepIndex = 0;
+        _hasBeenOutsideThreshold = false;
+        _debugDistance = null;
+        _isRecalculating = false;
+      });
+      _loadRoute(result);
+      debugPrint('✅ [Nav] 경로 재탐색 완료 - 새 step 수: ${_pointSteps.length}');
+    } catch (e) {
+      debugPrint('🔴 [Nav] 경로 재탐색 실패: $e');
+      if (mounted) setState(() => _isRecalculating = false);
     }
   }
 
@@ -187,7 +298,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                                       currentStep.turnType,
                                     ),
                                     instruction: currentStep.description ?? '',
-                                    distance: _route?.totalDistance ?? 0,
+                                    distance: _debugDistance?.round() ?? 0,
                                   )
                                 else if (_route != null)
                                   // 모든 step 완료
@@ -218,6 +329,36 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
               outsideThreshold: _hasBeenOutsideThreshold,
               threshold: _arrivalThresholdMeters,
             ),
+            if (_isRecalculating)
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: Container(
+                  color: ColorCollection.point.withValues(alpha: 0.9),
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: ColorCollection.point,
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Text(
+                        '경로 재탐색 중...',
+                        style: AppTextStyles.labelBold.copyWith(
+                          color: ColorCollection.point,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
           ],
         ),
       ),

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -172,7 +172,12 @@ class _NavigationScreenState extends State<NavigationScreen> {
       await Navigator.pushNamed(
         context,
         AppRouter.navigationing,
-        arguments: result,
+        arguments: {
+          'route': result,
+          'endX': _selectedLng!,
+          'endY': _selectedLat!,
+          'endName': _selectedName,
+        },
       );
 
       // 돌아왔을 때 입력값 초기화 및 위치 갱신

--- a/frontend/lib/features/navigation/navigation_step_card.dart
+++ b/frontend/lib/features/navigation/navigation_step_card.dart
@@ -47,6 +47,19 @@ class NavigationStepCard extends StatelessWidget {
     }
   }
 
+  String _getTtsMessage(DirectionType direction, int distance, String instruction) {
+    final action = switch (direction) {
+      DirectionType.straight => '직진',
+      DirectionType.left => '좌회전',
+      DirectionType.right => '우회전',
+      DirectionType.crosswalk => '횡단보도를 이용',
+    };
+
+    if (distance <= 15) return '$action하세요';
+    if (distance <= 50) return instruction.isNotEmpty ? instruction : '잠시 후 $action하세요';
+    return '계속 직진하세요';
+  }
+
   String _formatDistance(int distance) {
     if (distance >= 1000) {
       return '${(distance / 1000).toStringAsFixed(1)}km';
@@ -88,7 +101,7 @@ class NavigationStepCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        '${_formatDistance(distance)} ${_getDirectionLabel(direction)}',
+                        '${_formatDistance(distance)} 후 ${_getDirectionLabel(direction)}',
                         style: AppTextStyles.title2.copyWith(
                           color: ColorCollection.point,
                           fontSize: 20,
@@ -96,10 +109,12 @@ class NavigationStepCard extends StatelessWidget {
                       ),
                       const SizedBox(height: 5),
                       Text(
-                        '다음 안내까지',
+                        instruction,
                         style: AppTextStyles.labelRegular.copyWith(
                           color: ColorCollection.point,
                         ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ],
                   ),
@@ -129,7 +144,7 @@ class NavigationStepCard extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.only(top: 4),
                       child: Text(
-                        instruction,
+                        _getTtsMessage(direction, distance, instruction),
                         style: AppTextStyles.labelBold.copyWith(
                           color: ColorCollection.point,
                         ),


### PR DESCRIPTION
## 📎 Issue 번호
#7 #8 

## 📄 작업 내용 요약
 - 경로 이탈(30m 기준 3회 연속) 감지 시 현재 위치 기준으로 목적지까지 자동 재탐색                                                                                                                          
  - 재탐색 진행 중 상단 배너 표시                                                 
  - 길안내 step 카드에 실시간 GPS 거리 표시 및 거리에 따른 TTS 안내 문구 적용                                                                                                                               
    - > 50m: "계속 직진하세요"                                                                                                                                                                              
    - ≤ 50m: 백엔드 description 그대로                                                                                                                                                                      
    - ≤ 15m: "좌회전하세요" 등 즉각 행동 안내

## ✅ 체크리스트
- [x] 정상 경로 주행 시 재탐색 미발생 확인                                                                                                                                                                
- [x] 경로 이탈 시 재탐색 배너 표시 및 새 경로로 안내 전환 확인                                                                                                                                           
- [x] step 카드 상단: "${거리} 후 ${방향}" 형식 표시 확인                                                                                                                                                 
- [x] step 카드 하단: 거리에 따라 TTS 문구 변경 확인 
