### PR TITLE
[FIX] 회원탈퇴 후 로그아웃 API 미호출되도록 수정

### DIFF
--- a/frontend/lib/features/settings/settings_notification_widget.dart
+++ b/frontend/lib/features/settings/settings_notification_widget.dart
@@ -5,7 +5,14 @@ import 'package:safepath/common/theme/text_styles.dart';
 
 /// 알림 및 소리 섹션 (토글)
 class SettingsNotificationWidget extends StatefulWidget {
-  const SettingsNotificationWidget({super.key});
+  final bool initialVoiceGuidanceEnabled;
+  final void Function(bool)? onVoiceGuidanceChanged;
+
+  const SettingsNotificationWidget({
+    super.key,
+    required this.initialVoiceGuidanceEnabled,
+    this.onVoiceGuidanceChanged,
+  });
 
   @override
   State<SettingsNotificationWidget> createState() =>
@@ -16,7 +23,13 @@ class _SettingsNotificationWidgetState
     extends State<SettingsNotificationWidget> {
   bool _pushAlert = true;
   bool _soundEffect = false;
-  bool _voiceGuide = true;
+  late bool _voiceGuide;
+
+  @override
+  void initState() {
+    super.initState();
+    _voiceGuide = widget.initialVoiceGuidanceEnabled;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -50,7 +63,10 @@ class _SettingsNotificationWidgetState
             label: '음성 안내',
             description: 'TTS 음성 안내 기능',
             value: _voiceGuide,
-            onChanged: (v) => setState(() => _voiceGuide = v),
+            onChanged: (v) {
+              setState(() => _voiceGuide = v);
+              widget.onVoiceGuidanceChanged?.call(v);
+            },
           ),
         ],
       ),

--- a/frontend/lib/features/settings/settings_screen.dart
+++ b/frontend/lib/features/settings/settings_screen.dart
@@ -8,19 +8,45 @@ import 'package:safepath/features/settings/settings_notification_widget.dart';
 import 'package:safepath/features/settings/settings_profile_widget.dart';
 import 'package:safepath/features/settings/settings_style_widget.dart';
 import 'package:safepath/routes/app_router.dart';
+import 'package:safepath/service/user_settings_service.dart';
 
-class SettingsScreen extends StatelessWidget {
+class SettingsScreen extends StatefulWidget {
   final ScrollController? scrollController;
 
   const SettingsScreen({super.key, this.scrollController});
 
   @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  UserSettings? _settings;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final s = await UserSettingsService().fetch();
+    if (mounted) setState(() => _settings = s);
+  }
+
+  Future<void> _patch(UserSettings updated) async {
+    setState(() => _settings = updated);
+    UserSettingsService().patch(updated);
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final s = _settings;
+
     return Scaffold(
       appBar: const CustomTitleBar(title: '설정'),
       body: SafeArea(
         child: SingleChildScrollView(
-          controller: scrollController,
+          controller: widget.scrollController,
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -35,13 +61,31 @@ class SettingsScreen extends StatelessWidget {
               // 안내 스타일 개인화
               _SectionTitle(title: '안내 스타일 개인화'),
               const SizedBox(height: 12),
-              const SettingsStyleWidget(),
+              if (s != null)
+                SettingsStyleWidget(
+                  initialSettings: s,
+                  onSentenceLengthChanged: (v) =>
+                      _patch(s.copyWith(sentenceLength: v)),
+                  onVibrationChanged: (v) =>
+                      _patch(s.copyWith(vibrationStrength: v)),
+                  onGuidanceSpeedChanged: (v) =>
+                      _patch(s.copyWith(guidanceSpeed: v)),
+                )
+              else
+                const _SettingsLoadingPlaceholder(height: 220),
               const SizedBox(height: 32),
 
               // 알림 및 소리
               _SectionTitle(title: '알림 및 소리'),
               const SizedBox(height: 12),
-              const SettingsNotificationWidget(),
+              if (s != null)
+                SettingsNotificationWidget(
+                  initialVoiceGuidanceEnabled: s.voiceGuidanceEnabled,
+                  onVoiceGuidanceChanged: (v) =>
+                      _patch(s.copyWith(voiceGuidanceEnabled: v)),
+                )
+              else
+                const _SettingsLoadingPlaceholder(height: 160),
               const SizedBox(height: 32),
 
               // 앱 정보
@@ -91,6 +135,24 @@ class _SectionTitle extends StatelessWidget {
     return Text(
       title,
       style: AppTextStyles.title2.copyWith(color: ColorCollection.point),
+    );
+  }
+}
+
+class _SettingsLoadingPlaceholder extends StatelessWidget {
+  final double height;
+  const _SettingsLoadingPlaceholder({required this.height});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: Center(
+        child: CircularProgressIndicator(
+          color: ColorCollection.point,
+          strokeWidth: 2,
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -4,6 +4,35 @@ import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/service/tts_service.dart';
 
+enum MessageLength {
+  short,
+  medium,
+  long;
+
+  /// 백엔드 통신값: SHORT / MEDIUM / LONG
+  String get backendValue => name.toUpperCase();
+
+  /// 슬라이더 double 값: 0.0 / 0.5 / 1.0
+  double get sliderValue => index / 2.0;
+
+  String get displayLabel {
+    switch (this) {
+      case MessageLength.short:
+        return '간결';
+      case MessageLength.medium:
+        return '보통';
+      case MessageLength.long:
+        return '상세';
+    }
+  }
+
+  static MessageLength fromSlider(double v) {
+    if (v < 0.25) return MessageLength.short;
+    if (v < 0.75) return MessageLength.medium;
+    return MessageLength.long;
+  }
+}
+
 /// 안내 스타일 개인화 섹션 (슬라이더)
 class SettingsStyleWidget extends StatefulWidget {
   const SettingsStyleWidget({super.key});
@@ -13,7 +42,7 @@ class SettingsStyleWidget extends StatefulWidget {
 }
 
 class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
-  double _messageLength = 0.9;
+  MessageLength _messageLength = MessageLength.medium;
   double _vibrationStrength = 0.5;
 
   // TTS 속도: 0.5배속~5.0배속 → 슬라이더 0.0~1.0으로 변환
@@ -45,9 +74,13 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
         children: [
           _SliderRow(
             label: '안내 문장 길이',
-            value: _messageLength,
+            value: _messageLength.sliderValue,
             description: '안내 메시지의 상세도를 조절합니다.',
-            onChanged: (v) => setState(() => _messageLength = v),
+            divisions: 2,
+            tickLabels: const ['간결', '보통', '상세'],
+            valueFormatter: (_) => _messageLength.displayLabel,
+            onChanged: (v) =>
+                setState(() => _messageLength = MessageLength.fromSlider(v)),
           ),
           const SizedBox(height: 4),
           Divider(
@@ -92,6 +125,8 @@ class _SliderRow extends StatelessWidget {
   final String description;
   final ValueChanged<double> onChanged;
   final String Function(double)? valueFormatter;
+  final int? divisions;
+  final List<String>? tickLabels;
 
   const _SliderRow({
     required this.label,
@@ -99,6 +134,8 @@ class _SliderRow extends StatelessWidget {
     required this.description,
     required this.onChanged,
     this.valueFormatter,
+    this.divisions,
+    this.tickLabels,
   });
 
   String get _displayValue => valueFormatter != null
@@ -140,8 +177,34 @@ class _SliderRow extends StatelessWidget {
               overlayShape: SliderComponentShape.noOverlay,
               inactiveTrackColor: ColorCollection.point.withValues(alpha: 0.15),
             ),
-            child: Slider(value: value, onChanged: onChanged),
+            child: Slider(
+              value: value,
+              onChanged: onChanged,
+              divisions: divisions,
+            ),
           ),
+          if (tickLabels != null) ...[
+            const SizedBox(height: 5),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: tickLabels!
+                    .map(
+                      (t) => Text(
+                        t,
+                        style: AppTextStyles.labelRegular.copyWith(
+                          color: ColorCollection.point,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 16,
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
           SizedBox(height: 8),
           Text(
             description,

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
+import 'package:safepath/service/tts_service.dart';
 
 /// 안내 스타일 개인화 섹션 (슬라이더)
 class SettingsStyleWidget extends StatefulWidget {
@@ -14,6 +15,20 @@ class SettingsStyleWidget extends StatefulWidget {
 class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
   double _messageLength = 0.9;
   double _vibrationStrength = 0.5;
+
+  // TTS 속도: 0.5배속~5.0배속 → 슬라이더 0.0~1.0으로 변환
+  static const double _ttsMin = 0.5;
+  static const double _ttsMax = 5.0;
+
+  late double _ttsSpeed;
+
+  @override
+  void initState() {
+    super.initState();
+    _ttsSpeed = (TtsService.defaultSpeechRate - _ttsMin) / (_ttsMax - _ttsMin);
+  }
+
+  double get _ttsSpeedValue => _ttsMin + _ttsSpeed * (_ttsMax - _ttsMin);
 
   @override
   Widget build(BuildContext context) {
@@ -41,6 +56,25 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
             height: 28,
           ),
           _SliderRow(
+            label: '안내 문장 빠르기',
+            value: _ttsSpeed,
+            description: '안내 메시지의 재생 속도를 조절합니다.',
+            valueFormatter: (v) {
+              final speed = _ttsMin + v * (_ttsMax - _ttsMin);
+              return '${speed.toStringAsFixed(1)}배속';
+            },
+            onChanged: (v) {
+              setState(() => _ttsSpeed = v);
+              TtsService().setSpeechRate(_ttsSpeedValue);
+            },
+          ),
+          const SizedBox(height: 4),
+          Divider(
+            color: ColorCollection.point.withValues(alpha: 0.2),
+            thickness: 1,
+            height: 28,
+          ),
+          _SliderRow(
             label: '진동 강도',
             value: _vibrationStrength,
             description: '경고 진동의 강도를 조절합니다.',
@@ -57,19 +91,24 @@ class _SliderRow extends StatelessWidget {
   final double value;
   final String description;
   final ValueChanged<double> onChanged;
+  final String Function(double)? valueFormatter;
 
   const _SliderRow({
     required this.label,
     required this.value,
     required this.description,
     required this.onChanged,
+    this.valueFormatter,
   });
+
+  String get _displayValue => valueFormatter != null
+      ? valueFormatter!(value)
+      : '${(value * 100).round()}%';
 
   @override
   Widget build(BuildContext context) {
-    final percent = '${(value * 100).round()}%';
     return Semantics(
-      label: '$label $percent. $description',
+      label: '$label $_displayValue. $description',
       excludeSemantics: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -85,7 +124,7 @@ class _SliderRow extends StatelessWidget {
                 ),
               ),
               Text(
-                percent,
+                _displayValue,
                 style: AppTextStyles.labelBold.copyWith(
                   color: ColorCollection.main,
                 ),

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -3,58 +3,51 @@ import 'package:flutter/material.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/service/tts_service.dart';
-
-enum MessageLength {
-  short,
-  medium,
-  long;
-
-  /// 백엔드 통신값: SHORT / MEDIUM / LONG
-  String get backendValue => name.toUpperCase();
-
-  /// 슬라이더 double 값: 0.0 / 0.5 / 1.0
-  double get sliderValue => index / 2.0;
-
-  String get displayLabel {
-    switch (this) {
-      case MessageLength.short:
-        return '간결';
-      case MessageLength.medium:
-        return '보통';
-      case MessageLength.long:
-        return '상세';
-    }
-  }
-
-  static MessageLength fromSlider(double v) {
-    if (v < 0.25) return MessageLength.short;
-    if (v < 0.75) return MessageLength.medium;
-    return MessageLength.long;
-  }
-}
+import 'package:safepath/service/user_settings_service.dart';
 
 /// 안내 스타일 개인화 섹션 (슬라이더)
 class SettingsStyleWidget extends StatefulWidget {
-  const SettingsStyleWidget({super.key});
+  final UserSettings initialSettings;
+  final void Function(MessageLength)? onSentenceLengthChanged;
+  final void Function(int)? onVibrationChanged;
+  final void Function(double)? onGuidanceSpeedChanged;
+
+  const SettingsStyleWidget({
+    super.key,
+    required this.initialSettings,
+    this.onSentenceLengthChanged,
+    this.onVibrationChanged,
+    this.onGuidanceSpeedChanged,
+  });
 
   @override
   State<SettingsStyleWidget> createState() => _SettingsStyleWidgetState();
 }
 
 class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
-  MessageLength _messageLength = MessageLength.medium;
-  double _vibrationStrength = 0.5;
-
   // TTS 속도: 0.5배속~5.0배속 → 슬라이더 0.0~1.0으로 변환
   static const double _ttsMin = 0.5;
   static const double _ttsMax = 5.0;
 
-  late double _ttsSpeed;
+  // 진동 강도: 백엔드 int 값 최대치 (Java Integer.MAX_VALUE)
+  static const int _vibrationMax = 2147483647;
+
+  late MessageLength _messageLength;
+  late double _vibrationStrength; // 슬라이더 0.0~1.0
+  late double _ttsSpeed; // 슬라이더 0.0~1.0
 
   @override
   void initState() {
     super.initState();
-    _ttsSpeed = (TtsService.defaultSpeechRate - _ttsMin) / (_ttsMax - _ttsMin);
+    _messageLength = widget.initialSettings.sentenceLength;
+    _vibrationStrength =
+        (widget.initialSettings.vibrationStrength / _vibrationMax).clamp(
+          0.0,
+          1.0,
+        );
+    final speed = widget.initialSettings.guidanceSpeed;
+    _ttsSpeed =
+        ((speed - _ttsMin) / (_ttsMax - _ttsMin)).clamp(0.0, 1.0);
   }
 
   double get _ttsSpeedValue => _ttsMin + _ttsSpeed * (_ttsMax - _ttsMin);
@@ -81,6 +74,8 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
             valueFormatter: (_) => _messageLength.displayLabel,
             onChanged: (v) =>
                 setState(() => _messageLength = MessageLength.fromSlider(v)),
+            onChangeEnd: (_) =>
+                widget.onSentenceLengthChanged?.call(_messageLength),
           ),
           const SizedBox(height: 4),
           Divider(
@@ -92,6 +87,8 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
             label: '안내 문장 빠르기',
             value: _ttsSpeed,
             description: '안내 메시지의 재생 속도를 조절합니다.',
+            // 0.5~5.0배속, 0.1 단위 스냅: (5.0 - 0.5) / 0.1 = 45 divisions
+            divisions: 45,
             valueFormatter: (v) {
               final speed = _ttsMin + v * (_ttsMax - _ttsMin);
               return '${speed.toStringAsFixed(1)}배속';
@@ -100,6 +97,8 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
               setState(() => _ttsSpeed = v);
               TtsService().setSpeechRate(_ttsSpeedValue);
             },
+            onChangeEnd: (_) =>
+                widget.onGuidanceSpeedChanged?.call(_ttsSpeedValue),
           ),
           const SizedBox(height: 4),
           Divider(
@@ -112,6 +111,9 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
             value: _vibrationStrength,
             description: '경고 진동의 강도를 조절합니다.',
             onChanged: (v) => setState(() => _vibrationStrength = v),
+            onChangeEnd: (v) => widget.onVibrationChanged?.call(
+              (v * _vibrationMax).round(),
+            ),
           ),
         ],
       ),
@@ -124,6 +126,7 @@ class _SliderRow extends StatelessWidget {
   final double value;
   final String description;
   final ValueChanged<double> onChanged;
+  final ValueChanged<double>? onChangeEnd;
   final String Function(double)? valueFormatter;
   final int? divisions;
   final List<String>? tickLabels;
@@ -133,14 +136,14 @@ class _SliderRow extends StatelessWidget {
     required this.value,
     required this.description,
     required this.onChanged,
+    this.onChangeEnd,
     this.valueFormatter,
     this.divisions,
     this.tickLabels,
   });
 
-  String get _displayValue => valueFormatter != null
-      ? valueFormatter!(value)
-      : '${(value * 100).round()}%';
+  String get _displayValue =>
+      valueFormatter != null ? valueFormatter!(value) : '${(value * 100).round()}%';
 
   @override
   Widget build(BuildContext context) {
@@ -168,7 +171,7 @@ class _SliderRow extends StatelessWidget {
               ),
             ],
           ),
-          SizedBox(height: 14),
+          const SizedBox(height: 14),
           SliderTheme(
             data: SliderTheme.of(context).copyWith(
               trackHeight: 13,
@@ -180,6 +183,7 @@ class _SliderRow extends StatelessWidget {
             child: Slider(
               value: value,
               onChanged: onChanged,
+              onChangeEnd: onChangeEnd,
               divisions: divisions,
             ),
           ),
@@ -205,7 +209,7 @@ class _SliderRow extends StatelessWidget {
             ),
             const SizedBox(height: 8),
           ],
-          SizedBox(height: 8),
+          const SizedBox(height: 8),
           Text(
             description,
             style: AppTextStyles.labelRegular.copyWith(
@@ -292,7 +296,7 @@ class _GradientTrackShape extends SliderTrackShape {
   }
 }
 
-// ─── 가로형 흰색 Thumb ────────────────────────────────────────────────────────
+// ─── 가로형 Thumb ─────────────────────────────────────────────────────────────
 
 class _RoundedRectThumbShape extends SliderComponentShape {
   const _RoundedRectThumbShape();

--- a/frontend/lib/features/settings/user_info_screen.dart
+++ b/frontend/lib/features/settings/user_info_screen.dart
@@ -63,7 +63,9 @@ class _UserInfoScreenState extends State<UserInfoScreen> {
     setState(() => _isLoading = true);
     try {
       final uri = Uri.parse('${const String.fromEnvironment('BASE_URL')}/api/users/me/profile');
+      debugPrint('🔴 [UserInfo] 회원탈퇴 요청: DELETE $uri');
       final response = await ApiClient().delete(uri);
+      debugPrint('🔴 [UserInfo] 회원탈퇴 응답: ${response.statusCode} / ${response.body}');
       if (response.statusCode != 200 && response.statusCode != 204) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -75,7 +77,7 @@ class _UserInfoScreenState extends State<UserInfoScreen> {
         }
         return;
       }
-      await AuthService().signOut();
+      await AuthService().clearLocalSession();
       if (mounted) {
         Navigator.pushNamedAndRemoveUntil(
           context,

--- a/frontend/lib/features/settings/user_info_screen.dart
+++ b/frontend/lib/features/settings/user_info_screen.dart
@@ -20,7 +20,7 @@ class _UserInfoScreenState extends State<UserInfoScreen> {
   Future<void> _onLogout() async {
     setState(() => _isLoading = true);
     try {
-      await AuthService().signOut();
+      await AuthService().clearLocalSession();
     } finally {
       if (mounted) {
         Navigator.pushNamedAndRemoveUntil(
@@ -43,7 +43,9 @@ class _UserInfoScreenState extends State<UserInfoScreen> {
         ),
         content: Text(
           '탈퇴하면 모든 데이터가 삭제되며\n복구할 수 없습니다. 계속하시겠습니까?',
-          style: AppTextStyles.labelRegular.copyWith(color: ColorCollection.point),
+          style: AppTextStyles.labelRegular.copyWith(
+            color: ColorCollection.point,
+          ),
         ),
         actions: [
           TextButton(
@@ -62,10 +64,14 @@ class _UserInfoScreenState extends State<UserInfoScreen> {
 
     setState(() => _isLoading = true);
     try {
-      final uri = Uri.parse('${const String.fromEnvironment('BASE_URL')}/api/users/me/profile');
+      final uri = Uri.parse(
+        '${const String.fromEnvironment('BASE_URL')}/api/users/me/profile',
+      );
       debugPrint('🔴 [UserInfo] 회원탈퇴 요청: DELETE $uri');
       final response = await ApiClient().delete(uri);
-      debugPrint('🔴 [UserInfo] 회원탈퇴 응답: ${response.statusCode} / ${response.body}');
+      debugPrint(
+        '🔴 [UserInfo] 회원탈퇴 응답: ${response.statusCode} / ${response.body}',
+      );
       if (response.statusCode != 200 && response.statusCode != 204) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -134,8 +140,7 @@ class _UserInfoScreenState extends State<UserInfoScreen> {
                   ),
                 ],
               ),
-              if (_isLoading)
-                const Center(child: CircularProgressIndicator()),
+              if (_isLoading) const Center(child: CircularProgressIndicator()),
             ],
           ),
         ),

--- a/frontend/lib/service/api_client.dart
+++ b/frontend/lib/service/api_client.dart
@@ -26,6 +26,9 @@ class ApiClient {
   Future<http.Response> put(Uri uri, {Object? body}) =>
       _send('PUT', uri, body: body);
 
+  Future<http.Response> patch(Uri uri, {Object? body}) =>
+      _send('PATCH', uri, body: body);
+
   Future<http.Response> delete(Uri uri) => _send('DELETE', uri);
 
   Future<http.Response> _send(
@@ -69,6 +72,8 @@ class ApiClient {
         return http.post(uri, headers: headers, body: encoded);
       case 'PUT':
         return http.put(uri, headers: headers, body: encoded);
+      case 'PATCH':
+        return http.patch(uri, headers: headers, body: encoded);
       case 'DELETE':
         return http.delete(uri, headers: headers);
       default:

--- a/frontend/lib/service/auth_service.dart
+++ b/frontend/lib/service/auth_service.dart
@@ -131,12 +131,15 @@ class AuthService {
 
   // ─── 로컬 세션 정리 ──────────────────────────────────────
 
-  /// 회원탈퇴 등 서버 logout 호출 없이 로컬 토큰만 삭제할 때 사용
+  /// 회원탈퇴 후 호출. logout API 없이 로컬 토큰 삭제 + Kakao 앱 연결 해제(unlink)
   Future<void> clearLocalSession() async {
     await TokenStorage().clear();
     try {
-      await UserApi.instance.logout();
-    } catch (_) {}
+      await UserApi.instance.unlink();
+      debugPrint('🟡 [Auth] Kakao 연결 해제(unlink) 완료');
+    } catch (e) {
+      debugPrint('🔴 [Auth] Kakao unlink 실패: $e');
+    }
     debugPrint('🟡 [Auth] 로컬 세션 정리 완료');
   }
 }

--- a/frontend/lib/service/auth_service.dart
+++ b/frontend/lib/service/auth_service.dart
@@ -128,6 +128,17 @@ class AuthService {
       await UserApi.instance.logout();
     } catch (_) {}
   }
+
+  // ─── 로컬 세션 정리 ──────────────────────────────────────
+
+  /// 회원탈퇴 등 서버 logout 호출 없이 로컬 토큰만 삭제할 때 사용
+  Future<void> clearLocalSession() async {
+    await TokenStorage().clear();
+    try {
+      await UserApi.instance.logout();
+    } catch (_) {}
+    debugPrint('🟡 [Auth] 로컬 세션 정리 완료');
+  }
 }
 
 /// 로그인 결과

--- a/frontend/lib/service/tts_service.dart
+++ b/frontend/lib/service/tts_service.dart
@@ -24,13 +24,15 @@ class TtsService {
   bool _initialized = false;
   bool _isSpeaking = false;
 
+  static const double defaultSpeechRate = 2.0;
+
   // ─── 초기화 ────────────────────────────────────────────────────────────────
 
   Future<void> _init() async {
     if (_initialized) return;
 
     await _tts.setLanguage('ko-KR');
-    await _tts.setSpeechRate(0.45); // 너무 빠르면 안내문 알아듣기 어려움
+    await _tts.setSpeechRate(defaultSpeechRate);
     await _tts.setVolume(1.0);
     await _tts.setPitch(1.0);
 
@@ -80,6 +82,14 @@ class TtsService {
 
     debugPrint('🔊 [TTS] 출력: $text');
     await _tts.speak(text);
+  }
+
+  // ─── 속도 조절 ─────────────────────────────────────────────────────────────
+
+  /// 음성 속도를 변경한다. 범위: 0.5(느림) ~ 5.0(빠름)
+  Future<void> setSpeechRate(double rate) async {
+    await _init();
+    await _tts.setSpeechRate(rate.clamp(0.5, 5.0));
   }
 
   // ─── 중지 ──────────────────────────────────────────────────────────────────

--- a/frontend/lib/service/tts_service.dart
+++ b/frontend/lib/service/tts_service.dart
@@ -24,7 +24,7 @@ class TtsService {
   bool _initialized = false;
   bool _isSpeaking = false;
 
-  static const double defaultSpeechRate = 2.0;
+  static const double defaultSpeechRate = 1.0;
 
   // ─── 초기화 ────────────────────────────────────────────────────────────────
 

--- a/frontend/lib/service/user_settings_service.dart
+++ b/frontend/lib/service/user_settings_service.dart
@@ -1,0 +1,148 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:safepath/service/api_client.dart';
+
+// ─── 안내 문장 길이 enum ──────────────────────────────────────────────────────
+
+enum MessageLength {
+  short,
+  medium,
+  long;
+
+  /// 백엔드 통신값: SHORT / MEDIUM / LONG
+  String get backendValue => name.toUpperCase();
+
+  /// 슬라이더 double 값: 0.0 / 0.5 / 1.0
+  double get sliderValue => index / 2.0;
+
+  String get displayLabel {
+    switch (this) {
+      case MessageLength.short:
+        return '간결';
+      case MessageLength.medium:
+        return '보통';
+      case MessageLength.long:
+        return '상세';
+    }
+  }
+
+  static MessageLength fromSlider(double v) {
+    if (v < 0.25) return MessageLength.short;
+    if (v < 0.75) return MessageLength.medium;
+    return MessageLength.long;
+  }
+
+  static MessageLength fromBackend(String? value) {
+    return MessageLength.values.firstWhere(
+      (e) => e.backendValue == value,
+      orElse: () => MessageLength.medium,
+    );
+  }
+}
+
+// ─── 설정 데이터 모델 ─────────────────────────────────────────────────────────
+
+class UserSettings {
+  final MessageLength sentenceLength;
+  final int vibrationStrength;
+  final bool voiceGuidanceEnabled;
+
+  /// TTS 실제 재생 속도 (0.5배속 ~ 5.0배속)
+  final double guidanceSpeed;
+
+  const UserSettings({
+    required this.sentenceLength,
+    required this.vibrationStrength,
+    required this.voiceGuidanceEnabled,
+    required this.guidanceSpeed,
+  });
+
+  static const UserSettings defaults = UserSettings(
+    sentenceLength: MessageLength.medium,
+    vibrationStrength: 1073741824,
+    voiceGuidanceEnabled: true,
+    guidanceSpeed: 2.0,
+  );
+
+  factory UserSettings.fromJson(Map<String, dynamic> json) => UserSettings(
+    sentenceLength: MessageLength.fromBackend(json['sentenceLength'] as String?),
+    vibrationStrength:
+        (json['vibrationStrength'] as num?)?.toInt() ?? 1073741824,
+    voiceGuidanceEnabled: json['voiceGuidanceEnabled'] as bool? ?? true,
+    guidanceSpeed: (json['guidanceSpeed'] as num?)?.toDouble() ?? 2.0,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'sentenceLength': sentenceLength.backendValue,
+    'vibrationStrength': vibrationStrength,
+    'voiceGuidanceEnabled': voiceGuidanceEnabled,
+    'guidanceSpeed': double.parse(guidanceSpeed.toStringAsFixed(1)),
+  };
+
+  UserSettings copyWith({
+    MessageLength? sentenceLength,
+    int? vibrationStrength,
+    bool? voiceGuidanceEnabled,
+    double? guidanceSpeed,
+  }) => UserSettings(
+    sentenceLength: sentenceLength ?? this.sentenceLength,
+    vibrationStrength: vibrationStrength ?? this.vibrationStrength,
+    voiceGuidanceEnabled: voiceGuidanceEnabled ?? this.voiceGuidanceEnabled,
+    guidanceSpeed: guidanceSpeed ?? this.guidanceSpeed,
+  );
+}
+
+// ─── API 서비스 ───────────────────────────────────────────────────────────────
+
+class UserSettingsService {
+  static final UserSettingsService _instance = UserSettingsService._internal();
+  factory UserSettingsService() => _instance;
+  UserSettingsService._internal();
+
+  static const String _baseUrl = String.fromEnvironment('BASE_URL');
+
+  Future<UserSettings> fetch() async {
+    final uri = Uri.parse('$_baseUrl/api/users/me/settings');
+    debugPrint('🟢 [Settings] GET 요청: $uri');
+    try {
+      final response = await ApiClient().get(uri);
+      debugPrint('🟢 [Settings] GET 응답: ${response.statusCode} / ${response.body}');
+      if (response.statusCode == 200) {
+        final body = jsonDecode(response.body) as Map<String, dynamic>;
+        final settings = UserSettings.fromJson(body['data'] as Map<String, dynamic>);
+        debugPrint(
+          '✅ [Settings] GET 성공 → '
+          'sentenceLength=${settings.sentenceLength.backendValue}, '
+          'vibration=${settings.vibrationStrength}, '
+          'voiceGuide=${settings.voiceGuidanceEnabled}, '
+          'speed=${settings.guidanceSpeed}',
+        );
+        return settings;
+      }
+      debugPrint('🔴 [Settings] GET 실패: ${response.statusCode}');
+    } catch (e) {
+      debugPrint('🔴 [Settings] GET 오류: $e');
+    }
+    debugPrint('⚠️ [Settings] 기본값으로 fallback');
+    return UserSettings.defaults;
+  }
+
+  Future<void> patch(UserSettings settings) async {
+    final uri = Uri.parse('$_baseUrl/api/users/me/settings');
+    debugPrint(
+      '🟢 [Settings] PATCH 요청: $uri / body=${settings.toJson()}',
+    );
+    try {
+      final response = await ApiClient().patch(uri, body: settings.toJson());
+      debugPrint('🟢 [Settings] PATCH 응답: ${response.statusCode} / ${response.body}');
+      if (response.statusCode == 200) {
+        debugPrint('✅ [Settings] PATCH 성공');
+      } else {
+        debugPrint('🔴 [Settings] PATCH 실패: ${response.statusCode}');
+      }
+    } catch (e) {
+      debugPrint('🔴 [Settings] PATCH 오류: $e');
+    }
+  }
+}


### PR DESCRIPTION
## 📎 Issue 번호
<!-- close #번호 형식으로 작성 (예: close #42) -->
#39 

## 📄 작업 내용 요약
### 변경 사항
- 회원탈퇴 성공 후 불필요하게 호출되던 POST /api/auth/logout 제거
- AuthService에 clearLocalSession() 추가 (로컬 토큰 삭제 + 카카오 SDK unlink 수행)

### 참고
- feature/front/setting PR 내용이 포함되어 있어 해당 PR 머지 이후 머지 필요

## ✅ 체크리스트

- [x] 빌드 및 실행이 정상 동작한다
- [x] Breaking change 없음 (있다면 작업 내용 요약에 명시)
- [x] 테스트를 했거나, 기존 테스트로 충분하다
- [x] 커밋 메시지가 작업 내용과 일치한다
- [x] 셀프 리뷰를 완료했다