### PR TITLE
[FEAT] 길안내 출발 방향 안내 및 UX 개선

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -94,6 +94,24 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         .where((s) => s.type == 'LINE')
         .expand((s) => s.path ?? <LatLng>[])
         .toList();
+
+    // 경로 데이터로 방향 계산 (GPS 오차 무관)
+    if (_routePath.length >= 2) {
+      final startBearing = Geolocator.bearingBetween(
+        _routePath[0].latitude, _routePath[0].longitude,
+        _routePath[1].latitude, _routePath[1].longitude,
+      );
+      _startDirection = _bearingToDirection(startBearing);
+
+      final destBearing = Geolocator.bearingBetween(
+        _routePath[_routePath.length - 2].latitude,
+        _routePath[_routePath.length - 2].longitude,
+        _routePath[_routePath.length - 1].latitude,
+        _routePath[_routePath.length - 1].longitude,
+      );
+      _destinationDirection = _bearingToDirection(destBearing);
+    }
+
     debugPrint(
       '📍 [Nav] 전체 step 수: ${_pointSteps.length}, path 좌표 수: ${_routePath.length}',
     );
@@ -119,22 +137,6 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   }
 
   void _onPositionUpdate(Position position) {
-    // 방향 표시는 정확도 무관하게 업데이트
-    if (!_hasArrived &&
-        _destinationStep?.latitude != null &&
-        _destinationStep?.longitude != null) {
-      final bearing = Geolocator.bearingBetween(
-        position.latitude,
-        position.longitude,
-        _destinationStep!.latitude!,
-        _destinationStep!.longitude!,
-      );
-      final dir = _bearingToDirection(bearing);
-      if (_destinationDirection != dir) {
-        setState(() => _destinationDirection = dir);
-      }
-    }
-
     if (position.accuracy > 20) return;
 
     if (_currentStepIndex >= _pointSteps.length) {
@@ -160,23 +162,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         !_hasBeenOutsideThreshold &&
         !_hasShownStartOverview) {
       _hasShownStartOverview = true;
-      final targetStep = (distance < 20 && _pointSteps.length > 1)
-          ? _pointSteps[1]
-          : _pointSteps[_currentStepIndex];
-      String? direction;
-      if (targetStep.latitude != null && targetStep.longitude != null) {
-        final bearing = Geolocator.bearingBetween(
-          position.latitude,
-          position.longitude,
-          targetStep.latitude!,
-          targetStep.longitude!,
-        );
-        direction = _bearingToDirection(bearing);
-      }
-      setState(() {
-        _showStartOverview = true;
-        _startDirection = direction;
-      });
+      setState(() => _showStartOverview = true);
       Future.delayed(const Duration(seconds: 5), () {
         if (mounted) setState(() => _showStartOverview = false);
       });
@@ -221,19 +207,8 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
       _destinationStep!.longitude!,
     );
 
-    final bearing = Geolocator.bearingBetween(
-      position.latitude,
-      position.longitude,
-      _destinationStep!.latitude!,
-      _destinationStep!.longitude!,
-    );
-    final dir = _bearingToDirection(bearing);
-
-    setState(() {
-      _debugDistance = distance;
-      _destinationDirection = dir;
-    });
-    debugPrint('📍 [Nav] 목적지까지: ${distance.toStringAsFixed(1)}m ($dir)');
+    setState(() => _debugDistance = distance);
+    debugPrint('📍 [Nav] 목적지까지: ${distance.toStringAsFixed(1)}m ($_destinationDirection)');
 
     if (distance < _arrivalThresholdMeters) {
       setState(() => _hasArrived = true);

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -40,6 +40,8 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   double? _debugDistance;
   bool _hasArrived = false;
   bool _showStartOverview = false;
+  bool _hasShownStartOverview = false;
+  String? _startDirection;
 
   // 경로 이탈 감지
   static const double _deviationThresholdMeters = 20.0;
@@ -132,8 +134,25 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     );
 
     setState(() => _debugDistance = distance);
-    if (!_showStartOverview && !_hasBeenOutsideThreshold) {
-      setState(() => _showStartOverview = true);
+    if (!_showStartOverview && !_hasBeenOutsideThreshold && !_hasShownStartOverview) {
+      _hasShownStartOverview = true;
+      final targetStep = (distance < 20 && _pointSteps.length > 1)
+          ? _pointSteps[1]
+          : _pointSteps[_currentStepIndex];
+      String? direction;
+      if (targetStep.latitude != null && targetStep.longitude != null) {
+        final bearing = Geolocator.bearingBetween(
+          position.latitude,
+          position.longitude,
+          targetStep.latitude!,
+          targetStep.longitude!,
+        );
+        direction = _bearingToDirection(bearing);
+      }
+      setState(() {
+        _showStartOverview = true;
+        _startDirection = direction;
+      });
       Future.delayed(const Duration(seconds: 5), () {
         if (mounted) setState(() => _showStartOverview = false);
       });
@@ -217,16 +236,20 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     debugPrint('🔄 [Nav] 경로 재탐색 시작...');
 
     try {
-      final result = await NavigationService.getRoute(
-        startX: position.longitude,
-        startY: position.latitude,
-        endX: _endX!,
-        endY: _endY!,
-        startName: '현재 위치',
-        endName: _endName,
-      );
+      final results = await Future.wait([
+        NavigationService.getRoute(
+          startX: position.longitude,
+          startY: position.latitude,
+          endX: _endX!,
+          endY: _endY!,
+          startName: '현재 위치',
+          endName: _endName,
+        ),
+        Future.delayed(const Duration(milliseconds: 800)),
+      ]);
 
       if (!mounted) return;
+      final result = results[0] as RouteResult;
 
       setState(() {
         _route = result;
@@ -339,6 +362,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                                     firstStepDirection: currentStep != null
                                         ? _turnTypeToDirection(currentStep.turnType)
                                         : DirectionType.straight,
+                                    startDirection: _startDirection,
                                   )
                                 else if (currentStep != null)
                                   NavigationStepCard(
@@ -430,6 +454,18 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         ),
       ),
     );
+  }
+
+  String _bearingToDirection(double bearing) {
+    final b = (bearing + 360) % 360;
+    if (b < 22.5 || b >= 337.5) return '북쪽';
+    if (b < 67.5) return '북동쪽';
+    if (b < 112.5) return '동쪽';
+    if (b < 157.5) return '남동쪽';
+    if (b < 202.5) return '남쪽';
+    if (b < 247.5) return '남서쪽';
+    if (b < 292.5) return '서쪽';
+    return '북서쪽';
   }
 
   DirectionType _turnTypeToDirection(int? turnType) {

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -42,6 +42,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   bool _showStartOverview = false;
   bool _hasShownStartOverview = false;
   String? _startDirection;
+  String? _destinationDirection;
 
   // 경로 이탈 감지
   static const double _deviationThresholdMeters = 20.0;
@@ -118,6 +119,22 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   }
 
   void _onPositionUpdate(Position position) {
+    // 방향 표시는 정확도 무관하게 업데이트
+    if (!_hasArrived &&
+        _destinationStep?.latitude != null &&
+        _destinationStep?.longitude != null) {
+      final bearing = Geolocator.bearingBetween(
+        position.latitude,
+        position.longitude,
+        _destinationStep!.latitude!,
+        _destinationStep!.longitude!,
+      );
+      final dir = _bearingToDirection(bearing);
+      if (_destinationDirection != dir) {
+        setState(() => _destinationDirection = dir);
+      }
+    }
+
     if (position.accuracy > 20) return;
 
     if (_currentStepIndex >= _pointSteps.length) {
@@ -139,7 +156,9 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     );
 
     setState(() => _debugDistance = distance);
-    if (!_showStartOverview && !_hasBeenOutsideThreshold && !_hasShownStartOverview) {
+    if (!_showStartOverview &&
+        !_hasBeenOutsideThreshold &&
+        !_hasShownStartOverview) {
       _hasShownStartOverview = true;
       final targetStep = (distance < 20 && _pointSteps.length > 1)
           ? _pointSteps[1]
@@ -202,8 +221,19 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
       _destinationStep!.longitude!,
     );
 
-    setState(() => _debugDistance = distance);
-    debugPrint('📍 [Nav] 목적지까지: ${distance.toStringAsFixed(1)}m');
+    final bearing = Geolocator.bearingBetween(
+      position.latitude,
+      position.longitude,
+      _destinationStep!.latitude!,
+      _destinationStep!.longitude!,
+    );
+    final dir = _bearingToDirection(bearing);
+
+    setState(() {
+      _debugDistance = distance;
+      _destinationDirection = dir;
+    });
+    debugPrint('📍 [Nav] 목적지까지: ${distance.toStringAsFixed(1)}m ($dir)');
 
     if (distance < _arrivalThresholdMeters) {
       setState(() => _hasArrived = true);
@@ -333,7 +363,8 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                             time: _route != null
                                 ? (_route!.totalTime / 60).ceil()
                                 : 0,
-                            status: RouteStatus.safe,
+                            status:
+                                RouteStatus.safe, // TODO: 장애물탐지에 따른 경로 상태 반영
                           ),
                         ),
                         Padding(
@@ -367,9 +398,12 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                                   NavigationStartOverviewCard(
                                     totalDistance: _route!.totalDistance,
                                     totalTime: (_route!.totalTime / 60).ceil(),
-                                    firstStepDistance: _debugDistance?.round() ?? 0,
+                                    firstStepDistance:
+                                        _debugDistance?.round() ?? 0,
                                     firstStepDirection: currentStep != null
-                                        ? _turnTypeToDirection(currentStep.turnType)
+                                        ? _turnTypeToDirection(
+                                            currentStep.turnType,
+                                          )
                                         : DirectionType.straight,
                                     startDirection: _startDirection,
                                   )
@@ -407,8 +441,10 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                                 else if (_route != null)
                                   NavigationStepCard(
                                     direction: DirectionType.straight,
-                                    instruction: '목적지 방향으로 직진하세요',
-                                    distance: _debugDistance?.round() ?? 0,
+                                    instruction: _destinationDirection != null
+                                        ? '$_destinationDirection 방향으로 직진하세요'
+                                        : '목적지 방향으로 직진하세요',
+                                    distance: _debugDistance?.round(),
                                     isApproaching: false,
                                   ),
                                 SizedBox(height: bottomPad),

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -109,17 +109,22 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
 
   void _startLocationTracking() {
     _positionSub = Geolocator.getPositionStream(
-      locationSettings: const LocationSettings(
-        accuracy: LocationAccuracy.high,
-        distanceFilter: 5,
+      locationSettings: AndroidSettings(
+        accuracy: LocationAccuracy.best,
+        distanceFilter: 0,
+        intervalDuration: Duration.zero,
       ),
     ).listen(_onPositionUpdate);
   }
 
   void _onPositionUpdate(Position position) {
+    if (position.accuracy > 20) return;
+
     if (_currentStepIndex >= _pointSteps.length) {
       _trackDestination(position);
-      if (!_hasArrived) _checkDeviation(position);
+      if (!_hasArrived && (_debugDistance == null || _debugDistance! >= 50)) {
+        _checkDeviation(position);
+      }
       return;
     }
 
@@ -170,10 +175,14 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
       setState(() {
         _currentStepIndex++;
         _hasBeenOutsideThreshold = false;
+        _debugDistance = null;
       });
     } else {
       // 처음부터 threshold 이내 → 이미 지난 step으로 간주하고 skip
-      setState(() => _currentStepIndex++);
+      setState(() {
+        _currentStepIndex++;
+        _debugDistance = null;
+      });
     }
 
     _checkDeviation(position);

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -233,15 +233,20 @@ class _NavigationScreenState extends State<NavigationScreen> {
       throw Exception('위치 권한이 영구적으로 거부되었습니다.');
     }
 
-    // 현재 위치 가져오기 (5초 타임아웃 후 마지막 알려진 위치로 폴백)
+    // 정확도 20m 이하인 첫 번째 위치 반환 (최대 10초 대기, 초과 시 폴백)
     try {
-      return await Geolocator.getCurrentPosition(
-        desiredAccuracy: LocationAccuracy.high,
-      ).timeout(const Duration(seconds: 5));
+      return await Geolocator.getPositionStream(
+        locationSettings: AndroidSettings(
+          accuracy: LocationAccuracy.best,
+          distanceFilter: 0,
+        ),
+      ).firstWhere((p) => p.accuracy <= 20).timeout(const Duration(seconds: 10));
     } catch (_) {
       final last = await Geolocator.getLastKnownPosition();
       if (last != null) return last;
-      rethrow;
+      return await Geolocator.getCurrentPosition(
+        desiredAccuracy: LocationAccuracy.best,
+      );
     }
   }
 

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -43,6 +43,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
   int _currentPage = 1;
   bool _isLoadingMore = false;
   Timer? _debounce;
+  Timer? _reverseGeocodeRetry;
   Position? _currentPosition;
   bool isLoading = false;
   List<SavedPlace> _savedPlaces = [];
@@ -96,17 +97,35 @@ class _NavigationScreenState extends State<NavigationScreen> {
       final position = await getCurrentLocation();
       if (!mounted) return;
       _currentPosition = position;
-      final address = await PlaceService.reverseGeocode(
-        lat: position.latitude,
-        lng: position.longitude,
-      );
-      if (!mounted) return;
-      setState(() {
-        currentLocation = address ?? '현재 위치 로딩 실패';
-      });
+      await _fetchAddress(position);
     } catch (e) {
       debugPrint('🔴 위치 초기화 실패: $e');
-      if (mounted) setState(() => currentLocation = '현재 위치 불러오기 실패');
+      if (mounted) setState(() => currentLocation = '현재 위치 불러오는 중...');
+    }
+  }
+
+  Future<void> _fetchAddress(Position position) async {
+    final address = await PlaceService.reverseGeocode(
+      lat: position.latitude,
+      lng: position.longitude,
+    );
+    if (!mounted) return;
+    if (address != null) {
+      _reverseGeocodeRetry?.cancel();
+      setState(() => currentLocation = address);
+    } else {
+      _reverseGeocodeRetry?.cancel();
+      _reverseGeocodeRetry = Timer.periodic(const Duration(seconds: 5), (_) async {
+        final retryAddress = await PlaceService.reverseGeocode(
+          lat: position.latitude,
+          lng: position.longitude,
+        );
+        if (!mounted) return;
+        if (retryAddress != null) {
+          _reverseGeocodeRetry?.cancel();
+          setState(() => currentLocation = retryAddress);
+        }
+      });
     }
   }
 
@@ -115,6 +134,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
   void dispose() {
     destinationController.dispose();
     _debounce?.cancel();
+    _reverseGeocodeRetry?.cancel();
     super.dispose();
   }
 

--- a/frontend/lib/features/navigation/navigation_start_overview_card.dart
+++ b/frontend/lib/features/navigation/navigation_start_overview_card.dart
@@ -8,6 +8,7 @@ class NavigationStartOverviewCard extends StatelessWidget {
   final int totalTime;
   final int firstStepDistance;
   final DirectionType firstStepDirection;
+  final String? startDirection;
 
   const NavigationStartOverviewCard({
     super.key,
@@ -15,6 +16,7 @@ class NavigationStartOverviewCard extends StatelessWidget {
     required this.totalTime,
     required this.firstStepDistance,
     required this.firstStepDirection,
+    this.startDirection,
   });
 
   String _formatDistance(int distance) {
@@ -57,7 +59,9 @@ class NavigationStartOverviewCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            '길안내를 시작합니다.',
+            startDirection != null
+                ? '$startDirection 방향으로 출발하세요.'
+                : '길안내를 시작합니다.',
             style: AppTextStyles.labelBold.copyWith(color: ColorCollection.point),
           ),
           const SizedBox(height: 12),

--- a/frontend/lib/features/navigation/navigation_step_card.dart
+++ b/frontend/lib/features/navigation/navigation_step_card.dart
@@ -59,6 +59,7 @@ class NavigationStepCard extends StatelessWidget {
       DirectionType.crosswalk => '횡단보도를 이용',
     };
 
+    if (direction == DirectionType.straight) return '계속 직진하세요';
     if (distance <= 15) return '$action하세요';
     if (distance <= 30) return '잠시 후 $action하세요';
     if (distance <= 50) return instruction.isNotEmpty ? instruction : '잠시 후 $action하세요';
@@ -106,7 +107,9 @@ class NavigationStepCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        '${_formatDistance(distance)} 후 ${_getDirectionLabel(direction)}',
+                        direction == DirectionType.straight
+                            ? '${_formatDistance(distance)} 직진'
+                            : '${_formatDistance(distance)} 후 ${_getDirectionLabel(direction)}',
                         style: AppTextStyles.title2.copyWith(
                           color: ColorCollection.point,
                           fontSize: 20,

--- a/frontend/lib/features/navigation/navigation_step_card.dart
+++ b/frontend/lib/features/navigation/navigation_step_card.dart
@@ -12,14 +12,14 @@ enum DirectionType {
 class NavigationStepCard extends StatelessWidget {
   final DirectionType direction;
   final String instruction;
-  final int distance;
+  final int? distance;
   final bool isApproaching;
 
   const NavigationStepCard({
     super.key,
     required this.direction,
     required this.instruction,
-    required this.distance,
+    this.distance,
     this.isApproaching = true,
   });
 
@@ -49,8 +49,9 @@ class NavigationStepCard extends StatelessWidget {
     }
   }
 
-  String _getTtsMessage(DirectionType direction, int distance, String instruction) {
+  String _getTtsMessage(DirectionType direction, int? distance, String instruction) {
     if (!isApproaching) return instruction.isNotEmpty ? instruction : '계속 직진하세요';
+    if (distance == null) return '계속 직진하세요';
 
     final action = switch (direction) {
       DirectionType.straight => '직진',
@@ -66,10 +67,9 @@ class NavigationStepCard extends StatelessWidget {
     return '계속 직진하세요';
   }
 
-  String _formatDistance(int distance) {
-    if (distance >= 1000) {
-      return '${(distance / 1000).toStringAsFixed(1)}km';
-    }
+  String _formatDistance(int? distance) {
+    if (distance == null) return '--';
+    if (distance >= 1000) return '${(distance / 1000).toStringAsFixed(1)}km';
     return '${distance}m';
   }
 


### PR DESCRIPTION
## 📎 Issue 번호
#7 #8 

## 📄 작업 내용 요약
- 재탐색 후 출발 개요 카드 재표시 방지 (`_hasShownStartOverview`)                                                                                                                                         
- 재탐색 배너 최소 800ms 표시 보장 (`Future.wait`)                                                                                                                                                        
- 직진 step 상단 텍스트 "Xm 후 직진" → "Xm 직진" 으로 자연스럽게 수정                                                                                                                                     
- 직진 step TTS 항상 "계속 직진하세요" 고정
- 초기 위치 수신을 `getPositionStream` 기반으로 변경, accuracy ≤ 20m인 첫 위치 최대 10초 대기                                                                                                             
- 타임아웃 시 `getLastKnownPosition` → `getCurrentPosition` 순 폴백
- 스텝 전환 시 `_debugDistance` 초기화 — 이전 스텝 거리가 새 스텝 카드에 표시되는 버그 수정                                                                                                               
- 목적지 50m 이내에서 이탈 감지 비활성화                                                                                                                                                       
- POINT 스텝이 없는 짧은 경로에서 목적지 방위 실시간 계산 및 표시                                                                                                                                         
  ("목적지 방향으로 직진하세요" → "서쪽 방향으로 직진하세요")                                                                                                                                             
- 방향 계산은 GPS 정확도 필터 이전에 수행 (accuracy > 20m여도 표시 갱신)                                                                                                                                  
- reverseGeocode 404 실패 시 5초마다 재시도, 성공하면 타이머 자동 취소, 화면 이탈 시 재시도 타이머 dispose 처리  

## 📸 스크린샷 (UI 변경 시 작성, 없으면 삭제)
<img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/0c83633b-77ce-4a17-9d88-8a43cd23d1da" />


## ✅ 체크리스트
- [x] 길안내 시작 시 출발 개요 카드에 방위 방향 표시 확인 (북쪽/남동쪽 등)                                                                                                                                
- [x] 경로 재탐색 후 출발 개요 카드 재표시 안 되는지 확인                                                                                                                                                 
- [x] 경로 이탈 시 재탐색 배너 최소 800ms 표시 확인                                                                                                                                                       
- [x] 직진 step 카드 텍스트/TTS 자연스러운지 확인
