### PR TITLE
[FEAT] 회원 탈퇴 기능 구현

### DIFF
--- a/server/src/main/java/com/example/capstone/domain/place/repository/FavoritePlaceRepository.java
+++ b/server/src/main/java/com/example/capstone/domain/place/repository/FavoritePlaceRepository.java
@@ -1,6 +1,7 @@
 package com.example.capstone.domain.place.repository;
 
 import com.example.capstone.domain.place.entity.FavoritePlace;
+import com.example.capstone.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,6 @@ public interface FavoritePlaceRepository extends JpaRepository<FavoritePlace, Lo
     long countByUserId(Long userId);
 
     int deleteByIdAndUserId(Long id, Long userId);
+
+    void deleteByUser(User user);
 }

--- a/server/src/main/java/com/example/capstone/domain/place/repository/RecentPlaceRepository.java
+++ b/server/src/main/java/com/example/capstone/domain/place/repository/RecentPlaceRepository.java
@@ -1,6 +1,7 @@
 package com.example.capstone.domain.place.repository;
 
 import com.example.capstone.domain.place.entity.RecentPlace;
+import com.example.capstone.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,6 @@ public interface RecentPlaceRepository extends JpaRepository<RecentPlace, Long> 
     int deleteByIdAndUserId(Long id, Long userId);
 
     int deleteByUserId(Long userId);
+
+    void deleteByUser(User user);
 }

--- a/server/src/main/java/com/example/capstone/domain/user/controller/UserController.java
+++ b/server/src/main/java/com/example/capstone/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.capstone.domain.user.controller;
 
 import com.example.capstone.domain.user.dto.request.UpdateUserSettingRequest;
+import com.example.capstone.domain.user.dto.response.DeleteUserResponse;
 import com.example.capstone.domain.user.dto.response.ProfileResponse;
 import com.example.capstone.domain.user.dto.response.UserSettingResponse;
 import com.example.capstone.domain.user.service.UserService;
@@ -34,5 +35,10 @@ public class UserController {
             @RequestBody UpdateUserSettingRequest request
             ) {
         return ApiResponse.ok(userSettingService.updateUserSetting(userId, request));
+    }
+
+    @DeleteMapping("/profile")
+    public ApiResponse<DeleteUserResponse> deleteMyProfile(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.ok(userService.deleteMyProfile(userId));
     }
 }

--- a/server/src/main/java/com/example/capstone/domain/user/dto/response/DeleteUserResponse.java
+++ b/server/src/main/java/com/example/capstone/domain/user/dto/response/DeleteUserResponse.java
@@ -1,0 +1,4 @@
+package com.example.capstone.domain.user.dto.response;
+
+public record DeleteUserResponse(boolean deleted) {
+}

--- a/server/src/main/java/com/example/capstone/domain/user/repository/UserSettingRepository.java
+++ b/server/src/main/java/com/example/capstone/domain/user/repository/UserSettingRepository.java
@@ -1,5 +1,6 @@
 package com.example.capstone.domain.user.repository;
 
+import com.example.capstone.domain.user.entity.User;
 import com.example.capstone.domain.user.entity.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,5 @@ import java.util.Optional;
 public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {
 
     Optional<UserSetting> findByUserId(Long userId);
+    void deleteByUser(User user);
 }

--- a/server/src/main/java/com/example/capstone/domain/user/service/UserService.java
+++ b/server/src/main/java/com/example/capstone/domain/user/service/UserService.java
@@ -1,10 +1,15 @@
 package com.example.capstone.domain.user.service;
 
+import com.example.capstone.domain.auth.repository.RefreshTokenRepository;
+import com.example.capstone.domain.place.repository.FavoritePlaceRepository;
+import com.example.capstone.domain.place.repository.RecentPlaceRepository;
+import com.example.capstone.domain.user.dto.response.DeleteUserResponse;
 import com.example.capstone.domain.user.dto.response.ProfileResponse;
 import com.example.capstone.domain.user.entity.User;
 import com.example.capstone.domain.user.exception.UserErrorCode;
 import com.example.capstone.domain.user.exception.UserException;
 import com.example.capstone.domain.user.repository.UserRepository;
+import com.example.capstone.domain.user.repository.UserSettingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final FavoritePlaceRepository favoritePlaceRepository;
+    private final RecentPlaceRepository recentPlaceRepository;
+    private final UserSettingRepository userSettingRepository;
 
     public ProfileResponse getMyProfile(Long userId) {
         User user = userRepository.findById(userId)
@@ -27,5 +36,20 @@ public class UserService {
                 user.getCreatedAt(),
                 user.getUpdatedAt()
         );
+    }
+
+    @Transactional
+    public DeleteUserResponse deleteMyProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        refreshTokenRepository.deleteByUser(user);
+        favoritePlaceRepository.deleteByUser(user);
+        recentPlaceRepository.deleteByUser(user);
+        userSettingRepository.deleteByUser(user);
+
+        userRepository.delete(user);
+
+        return new DeleteUserResponse(true);
     }
 }

--- a/server/src/main/java/com/example/capstone/domain/user/service/UserService.java
+++ b/server/src/main/java/com/example/capstone/domain/user/service/UserService.java
@@ -1,10 +1,15 @@
 package com.example.capstone.domain.user.service;
 
+import com.example.capstone.domain.auth.repository.RefreshTokenRepository;
+import com.example.capstone.domain.place.repository.FavoritePlaceRepository;
+import com.example.capstone.domain.place.repository.RecentPlaceRepository;
+import com.example.capstone.domain.user.dto.response.DeleteUserResponse;
 import com.example.capstone.domain.user.dto.response.ProfileResponse;
 import com.example.capstone.domain.user.entity.User;
 import com.example.capstone.domain.user.exception.UserErrorCode;
 import com.example.capstone.domain.user.exception.UserException;
 import com.example.capstone.domain.user.repository.UserRepository;
+import com.example.capstone.domain.user.repository.UserSettingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final FavoritePlaceRepository favoritePlaceRepository;
+    private final RecentPlaceRepository recentPlaceRepository;
+    private final UserSettingRepository userSettingRepository;
 
     public ProfileResponse getMyProfile(Long userId) {
         User user = userRepository.findById(userId)
@@ -27,5 +36,19 @@ public class UserService {
                 user.getCreatedAt(),
                 user.getUpdatedAt()
         );
+    }
+
+    public DeleteUserResponse deleteMyProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        refreshTokenRepository.deleteByUser(user);
+        favoritePlaceRepository.deleteByUser(user);
+        recentPlaceRepository.deleteByUser(user);
+        userSettingRepository.deleteByUser(user);
+
+        userRepository.delete(user);
+
+        return new DeleteUserResponse(true);
     }
 }


### PR DESCRIPTION
## 📎 Issue 번호
<!-- close #35  -->

## 📄 작업 내용 요약
- 회원 탈퇴 요청 시 즐겨찾기 장소, refresh token 등 관련 데이터 삭제
- 유저 테이블에서 유저 삭제

## ✅ 체크리스트

- [x] 데이터베이스에서 유저 관련 모든 정보가 삭제된다
- [x] 새로 카카오 로그인을 하면 새로운 유저가 생성된다

## 💬 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분, 우려 사항, 논의할 내용 등 -->