### PR TITLE
[FEAT] 길찾기 화면 실시간 장애물 탐지 연동

### DIFF
--- a/frontend/ios/Podfile
+++ b/frontend/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '13.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -45,5 +45,13 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>장애물 탐지를 위해 카메라 접근이 필요합니다.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>목적지 음성 입력을 위해 마이크 접근이 필요합니다.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>목적지 음성 입력을 위해 음성 인식 기능이 필요합니다.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>실시간 위치 기반 길안내를 위해 위치 접근이 필요합니다.</string>
 </dict>
 </plist>

--- a/frontend/lib/common/widgets/camera_debug_overlay.dart
+++ b/frontend/lib/common/widgets/camera_debug_overlay.dart
@@ -18,7 +18,10 @@ import 'package:safepath/service/camera_service.dart';
 ///     ],
 ///   )
 class CameraDebugOverlay extends StatefulWidget {
-  const CameraDebugOverlay({super.key});
+  /// true이면 좌상단 고정 (navigation용) — 기본값 false는 우상단 (detection용)
+  final bool anchorLeft;
+
+  const CameraDebugOverlay({super.key, this.anchorLeft = false});
 
   @override
   State<CameraDebugOverlay> createState() => _CameraDebugOverlayState();
@@ -50,7 +53,8 @@ class _CameraDebugOverlayState extends State<CameraDebugOverlay> {
 
     if (!_visible) {
       return Positioned(
-        right: 8,
+        right: widget.anchorLeft ? null : 8,
+        left: widget.anchorLeft ? 8 : null,
         top: 8,
         child: GestureDetector(
           onTap: () => setState(() => _visible = true),
@@ -70,10 +74,13 @@ class _CameraDebugOverlayState extends State<CameraDebugOverlay> {
     final isReady = controller != null && controller.value.isInitialized;
 
     return Positioned(
-      right: 8,
+      right: widget.anchorLeft ? null : 8,
+      left: widget.anchorLeft ? 8 : null,
       top: 8,
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
+        crossAxisAlignment: widget.anchorLeft
+            ? CrossAxisAlignment.start
+            : CrossAxisAlignment.end,
         children: [
           // 닫기 버튼
           GestureDetector(

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -10,8 +10,14 @@ import 'package:safepath/features/navigation/navigation_step_card.dart';
 import 'package:safepath/features/navigation/navigation_overview_card.dart';
 import 'package:safepath/features/navigation/navigation_start_overview_card.dart';
 import 'package:safepath/models/route_result.dart';
+import 'package:safepath/common/widgets/camera_debug_overlay.dart';
+import 'package:safepath/features/navigation/navigation_voiceguide_card.dart';
+import 'package:safepath/model/detection_event.dart';
+import 'package:safepath/service/camera_service.dart';
+import 'package:safepath/service/detection_ws_service.dart';
 import 'package:safepath/service/navigation_service.dart';
 import 'package:safepath/service/sound_effect_service.dart';
+import 'package:safepath/service/tts_service.dart';
 import 'package:safepath/service/vibration_service.dart';
 import 'dart:ui' show DisplayFeatureType;
 import 'package:flutter/services.dart';
@@ -52,6 +58,10 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   int _deviationCount = 0;
   bool _isRecalculating = false;
 
+  // 장애물 탐지 (카메라 + WS)
+  StreamSubscription<DetectionEvent>? _wsSub;
+  final List<DetectionEvent> _obstacles = [];
+
   @override
   void initState() {
     super.initState();
@@ -77,9 +87,50 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
       if (_route != null) {
         _loadRoute(_route!);
         _startLocationTracking();
+        _startObstacleDetection();
         _routeLoaded = true;
       }
     }
+  }
+
+  // ─── 장애물 탐지 시작 ────────────────────────────────────────────────────────
+
+  Future<void> _startObstacleDetection() async {
+    await CameraService().start(CameraMode.navigation);
+    await DetectionWsService().connect();
+    _wsSub = DetectionWsService().eventStream?.listen(_onObstacleEvent);
+  }
+
+  void _onObstacleEvent(DetectionEvent event) {
+    setState(() {
+      _obstacles.insert(0, event);
+      if (_obstacles.length > 3) _obstacles.removeLast();
+    });
+
+    VibrationService().vibrate(switch (event.alertLevel) {
+      'high' => VibrationEffect.obstacleLevel3,
+      'medium' => VibrationEffect.obstacleLevel2,
+      _ => VibrationEffect.obstacleLevel1,
+    });
+
+    if (event.guideText.isNotEmpty) {
+      TtsService().speak(
+        event.guideText,
+        interrupt: event.alertLevel == 'high',
+      );
+    }
+  }
+
+  String _obstacleText(DetectionEvent event) {
+    final particle = _hasTrailingConsonant(event.objectName) ? '이' : '가';
+    return '${event.clockDirection} 방향에 ${event.objectName}$particle 있습니다.';
+  }
+
+  bool _hasTrailingConsonant(String text) {
+    if (text.isEmpty) return false;
+    final code = text.codeUnitAt(text.length - 1);
+    if (code < 0xAC00 || code > 0xD7A3) return false;
+    return (code - 0xAC00) % 28 != 0;
   }
 
   void _loadRoute(RouteResult route) {
@@ -286,6 +337,10 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   @override
   void dispose() {
     _positionSub?.cancel();
+    _wsSub?.cancel();
+    CameraService().stop();
+    DetectionWsService().disconnect();
+    TtsService().stop();
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
@@ -365,72 +420,94 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                     ),
                   ),
                   const SizedBox(width: 24),
+                  // ── 우측: 길찾기 안내(고정) + 장애물 목록(스크롤) ──────────
                   Expanded(
                     child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        Expanded(
-                          child: SingleChildScrollView(
-                            padding: const EdgeInsets.symmetric(horizontal: 2),
-                            child: Column(
-                              children: [
-                                if (_showStartOverview && _route != null)
-                                  NavigationStartOverviewCard(
-                                    totalDistance: _route!.totalDistance,
-                                    totalTime: (_route!.totalTime / 60).ceil(),
-                                    firstStepDistance:
-                                        _debugDistance?.round() ?? 0,
-                                    firstStepDirection: currentStep != null
-                                        ? _turnTypeToDirection(
-                                            currentStep.turnType,
-                                          )
-                                        : DirectionType.straight,
-                                    startDirection: _startDirection,
-                                  )
-                                else if (currentStep != null)
-                                  NavigationStepCard(
-                                    direction: _turnTypeToDirection(
-                                      currentStep.turnType,
+                        // 길찾기 안내 카드 — 고정
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 2),
+                          child: () {
+                            if (_showStartOverview && _route != null) {
+                              return NavigationStartOverviewCard(
+                                totalDistance: _route!.totalDistance,
+                                totalTime: (_route!.totalTime / 60).ceil(),
+                                firstStepDistance:
+                                    _debugDistance?.round() ?? 0,
+                                firstStepDirection: currentStep != null
+                                    ? _turnTypeToDirection(
+                                        currentStep.turnType,
+                                      )
+                                    : DirectionType.straight,
+                                startDirection: _startDirection,
+                              );
+                            } else if (currentStep != null) {
+                              return NavigationStepCard(
+                                direction: _turnTypeToDirection(
+                                  currentStep.turnType,
+                                ),
+                                instruction: currentStep.description ?? '',
+                                distance: _debugDistance?.round() ?? 0,
+                                isApproaching: _hasBeenOutsideThreshold,
+                              );
+                            } else if (_hasArrived) {
+                              return Center(
+                                child: Column(
+                                  children: [
+                                    Text(
+                                      '목적지에 도착했습니다.',
+                                      style: AppTextStyles.labelRegular
+                                          .copyWith(
+                                            color: ColorCollection.point,
+                                          ),
                                     ),
-                                    instruction: currentStep.description ?? '',
-                                    distance: _debugDistance?.round() ?? 0,
-                                    isApproaching: _hasBeenOutsideThreshold,
-                                  )
-                                else if (_hasArrived)
-                                  Center(
-                                    child: Column(
-                                      children: [
-                                        Text(
-                                          '목적지에 도착했습니다.',
-                                          style: AppTextStyles.labelRegular
-                                              .copyWith(
-                                                color: ColorCollection.point,
-                                              ),
-                                        ),
-                                        const SizedBox(height: 4),
-                                        Text(
-                                          '경로 안내를 종료합니다.',
-                                          style: AppTextStyles.labelRegular
-                                              .copyWith(
-                                                color: ColorCollection.point,
-                                              ),
-                                        ),
-                                      ],
+                                    const SizedBox(height: 4),
+                                    Text(
+                                      '경로 안내를 종료합니다.',
+                                      style: AppTextStyles.labelRegular
+                                          .copyWith(
+                                            color: ColorCollection.point,
+                                          ),
                                     ),
-                                  )
-                                else if (_route != null)
-                                  NavigationStepCard(
-                                    direction: DirectionType.straight,
-                                    instruction: _destinationDirection != null
-                                        ? '$_destinationDirection 방향으로 직진하세요'
-                                        : '목적지 방향으로 직진하세요',
-                                    distance: _debugDistance?.round(),
-                                    isApproaching: false,
+                                  ],
+                                ),
+                              );
+                            } else if (_route != null) {
+                              return NavigationStepCard(
+                                direction: DirectionType.straight,
+                                instruction: _destinationDirection != null
+                                    ? '$_destinationDirection 방향으로 직진하세요'
+                                    : '목적지 방향으로 직진하세요',
+                                distance: _debugDistance?.round(),
+                                isApproaching: false,
+                              );
+                            }
+                            return const SizedBox.shrink();
+                          }(),
+                        ),
+                        // 장애물 안내 목록 — 스크롤 (최신 순)
+                        if (_obstacles.isNotEmpty) ...[
+                          const SizedBox(height: 12),
+                          Expanded(
+                            child: ListView.separated(
+                              padding: EdgeInsets.only(
+                                left: 2,
+                                right: 2,
+                                bottom: bottomPad,
+                              ),
+                              itemCount: _obstacles.length,
+                              separatorBuilder: (_, __) =>
+                                  const SizedBox(height: 10),
+                              itemBuilder: (_, index) =>
+                                  NavigationVoiceGuideCard(
+                                    voiceGuide:
+                                        _obstacleText(_obstacles[index]),
                                   ),
-                                SizedBox(height: bottomPad),
-                              ],
                             ),
                           ),
-                        ),
+                        ] else
+                          SizedBox(height: bottomPad),
                       ],
                     ),
                   ),
@@ -444,6 +521,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
               outsideThreshold: _hasBeenOutsideThreshold,
               threshold: _arrivalThresholdMeters,
             ),
+            const CameraDebugOverlay(anchorLeft: true),
             if (_isRecalculating)
               Positioned(
                 top: 0,

--- a/frontend/lib/service/camera_service.dart
+++ b/frontend/lib/service/camera_service.dart
@@ -44,7 +44,7 @@ class CameraService {
   static const String _baseUrl = String.fromEnvironment('BASE_URL');
 
   /// true → 카메라 대신 테스트 이미지(assets/images/test_detection.jpg)를 주기 전송
-  static const bool useTestImage = true;
+  static const bool useTestImage = false;
 
   /// 캡처 전송 주기
   static const Duration _captureInterval = Duration(milliseconds: 500);
@@ -194,7 +194,7 @@ class CameraService {
     }
   }
 
-  /// POST /api/guide/image 또는 navigation 엔드포인트로 이미지를 전송한다.
+  /// POST /api/guide/image 엔드포인트로 이미지를 전송한다.
   ///
   /// Request: multipart/form-data
   ///   - image      : JPEG 바이너리
@@ -203,10 +203,7 @@ class CameraService {
   /// Response: { "success": bool, "data": {}, "error": { ... } }
   /// success=true이고 HTTP 200일 때만 전송 성공으로 처리한다.
   Future<bool> _sendFrame(Uint8List bytes) async {
-    // detection 모드: /api/guide/image / navigation 모드: 별도 엔드포인트 (미구현)
-    final endpoint = _currentMode == CameraMode.detection
-        ? '$_baseUrl/api/guide/image'
-        : '$_baseUrl/api/navigation/frame'; // TODO: navigation 엔드포인트 확정 시 수정
+    final endpoint = '$_baseUrl/api/guide/image';
 
     final capturedAt = DateTime.now().toUtc().toIso8601String();
     final accessToken = await TokenStorage().accessToken;

--- a/frontend/lib/service/sound_effect_service.dart
+++ b/frontend/lib/service/sound_effect_service.dart
@@ -52,6 +52,10 @@ class SoundEffectService {
       stayAwake: false,
       isSpeakerphoneOn: false,
     ),
+    iOS: AudioContextIOS(
+      category: AVAudioSessionCategory.playback,
+      options: {AVAudioSessionOptions.mixWithOthers}, // TTS와 동시 재생
+    ),
   );
 
   static final _actionContext = AudioContext(
@@ -61,6 +65,10 @@ class SoundEffectService {
       audioFocus: AndroidAudioFocus.gainTransientMayDuck,
       stayAwake: false,
       isSpeakerphoneOn: false,
+    ),
+    iOS: AudioContextIOS(
+      category: AVAudioSessionCategory.playback,
+      options: {AVAudioSessionOptions.mixWithOthers}, // TTS와 동시 재생
     ),
   );
 


### PR DESCRIPTION
## 📎 Issue 번호
<!-- close #번호 형식으로 작성 (예: close #42) -->
#29 

## 📄 작업 내용 요약
- **CameraService** detection·navigation 이미지 전송 엔드포인트 `/api/guide/image`로 통일
- **CameraDebugOverlay** `anchorLeft` 파라미터 추가
  - navigation 화면에서 좌상단 고정(`anchorLeft: true`)으로 RouteDebugOverlay(우상단)와 겹침 방지
- **NavigationIngScreen** 실시간 장애물 탐지 연동
  - `CameraService(navigation)` + `DetectionWsService`로 장애물 탐지 시작/종료
  - `alertLevel`에 따른 진동 분리 (obstacleLevel1/2/3), `high` 시 TTS interrupt 우선 안내
  - 길찾기 안내 카드 **고정** + 장애물 목록(`NavigationVoiceGuideCard`) **스크롤** 표시 (최신 순, 최대 3개)
  - `dispose()` 시 WS 연결 해제, 카메라 정지, TTS 중단 처리

## 📸 스크린샷 (UI 변경 시 작성, 없으면 삭제)
<img width="2340" height="1080" alt="KakaoTalk_20260427_124234299" src="https://github.com/user-attachments/assets/f82daa9b-4a3c-45c4-a446-2dd8684549e8" />

## ✅ 체크리스트

- [x] 빌드 및 실행이 정상 동작한다
- [x] Breaking change 없음 (있다면 작업 내용 요약에 명시)
- [x] 테스트를 했거나, 기존 테스트로 충분하다
- [x] 커밋 메시지가 작업 내용과 일치한다
- [x] 셀프 리뷰를 완료했다

## 💬 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분, 우려 사항, 논의할 내용 등 -->
- 장애물 목록 최대 3개 제한이 네비게이션 UX에 맞는지 논의가 필요합니다. (현재 detection 또한 3개 제한으로 구현되어 있습니다.)