### PR TITLE
[FEAT] 장애물 alertLevel 기반 경로 상태(RouteStatus) 연동

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -61,6 +61,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   // 장애물 탐지 (카메라 + WS)
   StreamSubscription<DetectionEvent>? _wsSub;
   final List<DetectionEvent> _obstacles = [];
+  RouteStatus _routeStatus = RouteStatus.safe;
 
   @override
   void initState() {
@@ -105,6 +106,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     setState(() {
       _obstacles.insert(0, event);
       if (_obstacles.length > 3) _obstacles.removeLast();
+      _routeStatus = _computeRouteStatus();
     });
 
     VibrationService().vibrate(switch (event.alertLevel) {
@@ -119,6 +121,12 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         interrupt: event.alertLevel == 'high',
       );
     }
+  }
+
+  RouteStatus _computeRouteStatus() {
+    if (_obstacles.any((e) => e.alertLevel == 'high')) return RouteStatus.danger;
+    if (_obstacles.any((e) => e.alertLevel == 'medium')) return RouteStatus.warning;
+    return RouteStatus.safe;
   }
 
   String _obstacleText(DetectionEvent event) {
@@ -395,8 +403,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                             time: _route != null
                                 ? (_route!.totalTime / 60).ceil()
                                 : 0,
-                            status:
-                                RouteStatus.safe, // TODO: 장애물탐지에 따른 경로 상태 반영
+                            status: _routeStatus,
                           ),
                         ),
                         Padding(


### PR DESCRIPTION
## 📎 Issue 번호
<!-- close #번호 형식으로 작성 (예: close #42) -->
close #60 

## 📄 작업 내용 요약
- 기존 PR(#60) 리뷰 코멘트 반영
- RouteStatus 상태 필드 추가 및 관리 로직 구현
  - _routeStatus 필드 추가 (기본값: RouteStatus.safe)
  - _onObstacleEvent에서 장애물 목록 갱신 시 _computeRouteStatus() 호출하도록 수정
- 장애물 기반 경로 상태 계산 로직 추가
  - _computeRouteStatus() 메서드 구현
  - _obstacles 목록의 최고 alertLevel 기준으로 danger / warning / safe 반환
- UI 상태 연동
  - NavigationOverviewCard의 status 값 하드코딩 제거
  - RouteStatus.safe → _routeStatus로 변경
  - 관련 TODO 주석 제거

## ✅ 체크리스트

- [x] 빌드 및 실행이 정상 동작한다
- [x] Breaking change 없음 (있다면 작업 내용 요약에 명시)
- [x] 테스트를 했거나, 기존 테스트로 충분하다
- [x] 커밋 메시지가 작업 내용과 일치한다
- [x] 셀프 리뷰를 완료했다