### PR TITLE
[FEAT] 경로 안내 step 완수 로직 개선 및 TTS 임계값 조정

### DIFF
--- a/frontend/lib/common/widgets/route_debug_overlay.dart
+++ b/frontend/lib/common/widgets/route_debug_overlay.dart
@@ -26,6 +26,7 @@ class RouteDebugOverlay extends StatefulWidget {
   final double? distanceToStep;
   final bool outsideThreshold;
   final double threshold;
+  final double minDistanceToStep;
 
   const RouteDebugOverlay({
     super.key,
@@ -34,6 +35,7 @@ class RouteDebugOverlay extends StatefulWidget {
     required this.distanceToStep,
     required this.outsideThreshold,
     required this.threshold,
+    this.minDistanceToStep = double.infinity,
   });
 
   @override
@@ -142,6 +144,9 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
                           ? widget.outsideThreshold
                           : null,
                       threshold: widget.threshold,
+                      minDistanceToStep: i == widget.currentStepIndex
+                          ? widget.minDistanceToStep
+                          : double.infinity,
                     ),
                 ],
               ),
@@ -159,6 +164,7 @@ class _StepDebugCard extends StatelessWidget {
   final double? distanceToStep;
   final bool? outsideThreshold;
   final double threshold;
+  final double minDistanceToStep;
 
   const _StepDebugCard({
     required this.step,
@@ -166,6 +172,7 @@ class _StepDebugCard extends StatelessWidget {
     required this.distanceToStep,
     required this.outsideThreshold,
     required this.threshold,
+    this.minDistanceToStep = double.infinity,
   });
 
   DirectionType _turnTypeToDirection(int? turnType) {
@@ -265,14 +272,22 @@ class _StepDebugCard extends StatelessWidget {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                Text(
-                  outsideThreshold == true ? '진행 중' : '대기 중',
-                  style: TextStyle(
-                    color: outsideThreshold == true
-                        ? Colors.green
-                        : Colors.orange,
-                    fontSize: 9,
-                  ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      outsideThreshold == true ? '진행 중' : '대기 중',
+                      style: TextStyle(
+                        color: outsideThreshold == true ? Colors.green : Colors.orange,
+                        fontSize: 9,
+                      ),
+                    ),
+                    if (minDistanceToStep != double.infinity && outsideThreshold == true)
+                      Text(
+                        'pass: ${(distanceToStep! - minDistanceToStep).toStringAsFixed(1)}/8m',
+                        style: const TextStyle(color: Colors.cyan, fontSize: 9),
+                      ),
+                  ],
                 ),
               ],
             ),

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -44,7 +44,9 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   String _endName = '';
 
   static const double _arrivalThresholdMeters = 10;
+  static const double _passThroughOffsetMeters = 8;
   bool _hasBeenOutsideThreshold = false;
+  double _minDistanceToStep = double.infinity;
   double? _debugDistance;
   bool _hasArrived = false;
   bool _showStartOverview = false;
@@ -222,23 +224,31 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     }
     debugPrint(
       '📍 [Nav] step $_currentStepIndex/${_pointSteps.length - 1} | '
-      '남은 거리: ${distance.toStringAsFixed(1)}m | '
-      '${_hasBeenOutsideThreshold ? "진행 중" : "대기 중"} | '
-      '${_pointSteps[_currentStepIndex].description}',
+      '거리: ${distance.toStringAsFixed(1)}m | '
+      '최근접: ${_minDistanceToStep == double.infinity ? "-" : _minDistanceToStep.toStringAsFixed(1)}m | '
+      'pass-through: ${_minDistanceToStep < _arrivalThresholdMeters ? "${(distance - _minDistanceToStep).toStringAsFixed(1)}/${_passThroughOffsetMeters}m" : "대기"} | '
+      '${_hasBeenOutsideThreshold ? "진행 중" : "대기 중"}',
     );
+
+    if (distance < _minDistanceToStep) _minDistanceToStep = distance;
 
     if (distance >= _arrivalThresholdMeters) {
       _hasBeenOutsideThreshold = true;
     } else if (_hasBeenOutsideThreshold) {
-      setState(() {
-        _currentStepIndex++;
-        _hasBeenOutsideThreshold = false;
-        _debugDistance = null;
-      });
+      // pass-through: 최근접 거리에서 _passThroughOffsetMeters 이상 멀어졌을 때 완수
+      if (distance > _minDistanceToStep + _passThroughOffsetMeters) {
+        setState(() {
+          _currentStepIndex++;
+          _hasBeenOutsideThreshold = false;
+          _minDistanceToStep = double.infinity;
+          _debugDistance = null;
+        });
+      }
     } else {
       // 처음부터 threshold 이내 → 이미 지난 step으로 간주하고 skip
       setState(() {
         _currentStepIndex++;
+        _minDistanceToStep = double.infinity;
         _debugDistance = null;
       });
     }
@@ -493,6 +503,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                             child: ListView.separated(
                               padding: EdgeInsets.only(
                                 left: 2,
+                                top: 2,
                                 right: 2,
                                 bottom: bottomPad,
                               ),
@@ -520,6 +531,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
               distanceToStep: _debugDistance,
               outsideThreshold: _hasBeenOutsideThreshold,
               threshold: _arrivalThresholdMeters,
+              minDistanceToStep: _minDistanceToStep,
             ),
             const CameraDebugOverlay(anchorLeft: true),
             if (_isRecalculating)

--- a/frontend/lib/features/navigation/navigation_step_card.dart
+++ b/frontend/lib/features/navigation/navigation_step_card.dart
@@ -61,9 +61,9 @@ class NavigationStepCard extends StatelessWidget {
     };
 
     if (direction == DirectionType.straight) return '계속 직진하세요';
-    if (distance <= 15) return '$action하세요';
-    if (distance <= 30) return '잠시 후 $action하세요';
-    if (distance <= 50) return instruction.isNotEmpty ? instruction : '잠시 후 $action하세요';
+    if (distance <= 8) return '$action하세요';
+    if (distance <= 20) return '잠시 후 $action하세요';
+    if (distance <= 40) return instruction.isNotEmpty ? instruction : '잠시 후 $action하세요';
     return '계속 직진하세요';
   }
 


### PR DESCRIPTION
## 📎 Issue 번호
#96 

## 📄 작업 내용 요약
- **pass-through 완수 감지**: step 지점에 접근 후 최근접 거리에서 8m 이상 멀어졌을 때 step 완수 처리 → 횡단보도 등 통과 전 조기 완수 방지                                                                 
- **TTS 임계값 조정**: 행동 지시 ≤8m / 잠시 후 안내 ≤20m / 서버 제공 안내문 ≤40m
- **VoiceGuide 카드 border 수정**: ListView 첫 항목 상단 테두리 클리핑 현상 수정
- **디버그 오버레이 개선**: 현재 step의 최근접 거리(minDist) 및 pass-through 진행 거리(`pass: X/8m`) 실시간 표시

## ✅ 체크리스트
- [x] step 지점 통과 시 완수 처리 타이밍 확인 (접근 시 전환 없음 → 통과 8m 후 전환)                                                                                                                       
- [x] TTS 메시지가 거리 임계값에 맞게 표시되는지 확인                                                                                                                                                     
- [x] VoiceGuide 카드 여러 개일 때 첫 번째 카드 상단 테두리 정상 표시 확인                                                                                                                                
- [x] RouteDebugOverlay에서 pass-through 진행 상태 (`pass: X/8m`) 표시 확인

## 💬 리뷰 요청 사항
스탭 넘어가는 타이밍 확인 필요