### PR TITLE
[FEAT] 길찾기 TTS 음성 안내 구현

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -16,6 +16,7 @@ import 'package:safepath/model/detection_event.dart';
 import 'package:safepath/service/camera_service.dart';
 import 'package:safepath/service/detection_ws_service.dart';
 import 'package:safepath/service/navigation_service.dart';
+import 'package:safepath/service/navigation_tts_service.dart';
 import 'package:safepath/service/sound_effect_service.dart';
 import 'package:safepath/service/tts_service.dart';
 import 'package:safepath/service/vibration_service.dart';
@@ -121,6 +122,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
       TtsService().speak(
         event.guideText,
         interrupt: event.alertLevel == 'high',
+        channel: TtsChannel.detection,
       );
     }
   }
@@ -221,11 +223,22 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     );
 
     setState(() => _debugDistance = distance);
+    final direction = _turnTypeToDirection(step.turnType);
+
     if (!_showStartOverview &&
         !_hasBeenOutsideThreshold &&
         !_hasShownStartOverview) {
       _hasShownStartOverview = true;
       setState(() => _showStartOverview = true);
+      if (_route != null) {
+        NavigationTtsService().speakStartOverview(
+          startDirection: _startDirection,
+          totalTime: (_route!.totalTime / 60).ceil(),
+          firstStepDistance: distance.round(),
+          firstStepDirection: direction,
+          firstStepInstruction: step.description ?? '',
+        );
+      }
       Future.delayed(const Duration(seconds: 5), () {
         if (mounted) setState(() => _showStartOverview = false);
       });
@@ -242,8 +255,11 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
 
     if (distance >= _arrivalThresholdMeters) {
       _hasBeenOutsideThreshold = true;
+      NavigationTtsService().speakDistance(direction, distance.round(), step.description ?? '');
     } else if (_hasBeenOutsideThreshold) {
-      // pass-through: 최근접 거리에서 _passThroughOffsetMeters 이상 멀어졌을 때 완수
+      // pass-through zone — 8m 안내 포함
+      NavigationTtsService().speakDistance(direction, distance.round(), step.description ?? '');
+      // 최근접 거리에서 _passThroughOffsetMeters 이상 멀어졌을 때 완수
       if (distance > _minDistanceToStep + _passThroughOffsetMeters) {
         setState(() {
           _currentStepIndex++;
@@ -251,14 +267,16 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
           _minDistanceToStep = double.infinity;
           _debugDistance = null;
         });
+        _speakNextStepOrDestination();
       }
     } else {
-      // 처음부터 threshold 이내 → 이미 지난 step으로 간주하고 skip
+      // 처음부터 threshold 이내 → 이미 지난 step으로 간주하고 skip (TTS 없음)
       setState(() {
         _currentStepIndex++;
         _minDistanceToStep = double.infinity;
         _debugDistance = null;
       });
+      _speakNextStepOrDestination();
     }
 
     _checkDeviation(position);
@@ -283,6 +301,24 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
 
     if (distance < _arrivalThresholdMeters) {
       setState(() => _hasArrived = true);
+      NavigationTtsService().speakArrival();
+    }
+  }
+
+  void _speakNextStepOrDestination() {
+    if (_currentStepIndex < _pointSteps.length) {
+      final next = _pointSteps[_currentStepIndex];
+      NavigationTtsService().speakStep(
+        _turnTypeToDirection(next.turnType),
+        next.description ?? '',
+      );
+    } else {
+      // 모든 step 완료 → 목적지 직진 안내
+      NavigationTtsService().reset();
+      final msg = _destinationDirection != null
+          ? '$_destinationDirection 방향으로 직진하세요'
+          : '목적지 방향으로 직진하세요';
+      TtsService().speak(msg, interrupt: true, channel: TtsChannel.navigation);
     }
   }
 
@@ -340,11 +376,20 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         _route = result;
         _currentStepIndex = 0;
         _hasBeenOutsideThreshold = false;
+        _minDistanceToStep = double.infinity;
         _debugDistance = null;
         _hasArrived = false;
         _isRecalculating = false;
       });
       _loadRoute(result);
+      // 재탐색 후 overview 카드 없이 새 경로 첫 step 바로 안내
+      if (_pointSteps.isNotEmpty) {
+        final first = _pointSteps[0];
+        NavigationTtsService().speakStep(
+          _turnTypeToDirection(first.turnType),
+          first.description ?? '',
+        );
+      }
       debugPrint('✅ [Nav] 경로 재탐색 완료 - 새 step 수: ${_pointSteps.length}');
     } catch (e) {
       debugPrint('🔴 [Nav] 경로 재탐색 실패: $e');
@@ -354,6 +399,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
 
   @override
   void dispose() {
+    NavigationTtsService().reset();
     _positionSub?.cancel();
     _wsSub?.cancel();
     CameraService().stop();

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -238,6 +238,8 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
           firstStepDirection: direction,
           firstStepInstruction: step.description ?? '',
         );
+        // overview 종료 후 step[0] 서버 안내문 자동 재생
+        NavigationTtsService().speakAfterOverview(step.description ?? '');
       }
       Future.delayed(const Duration(seconds: 5), () {
         if (mounted) setState(() => _showStartOverview = false);

--- a/frontend/lib/service/navigation_tts_service.dart
+++ b/frontend/lib/service/navigation_tts_service.dart
@@ -1,0 +1,82 @@
+import 'package:safepath/features/navigation/navigation_step_card.dart';
+import 'package:safepath/service/tts_service.dart';
+
+class NavigationTtsService {
+  static final NavigationTtsService _instance = NavigationTtsService._internal();
+  factory NavigationTtsService() => _instance;
+  NavigationTtsService._internal();
+
+  // 현재 step에서 이미 읽은 임계값 추적 (step 전환 시 reset)
+  final Set<String> _announcedThresholds = {};
+
+  void reset() => _announcedThresholds.clear();
+
+  // step 전환 시 — 다음 step 안내 (끊고 즉시 출력)
+  void speakStep(DirectionType direction, String instruction) {
+    reset();
+    final msg = instruction.isNotEmpty
+        ? instruction
+        : (direction == DirectionType.straight ? '계속 직진하세요' : '${_actionText(direction)}하세요');
+    TtsService().speak(msg, interrupt: true, channel: TtsChannel.navigation);
+  }
+
+  // 거리 임계값 도달 시 (≤40m → ≤20m → ≤8m)
+  void speakDistance(DirectionType direction, int distance, String serverInstruction) {
+    if (direction == DirectionType.straight) return;
+
+    final action = _actionText(direction);
+
+    if (distance <= 8 && !_announcedThresholds.contains('8')) {
+      _announcedThresholds.addAll({'8', '20', '40'});
+      TtsService().speak('$action하세요', interrupt: true, channel: TtsChannel.navigation);
+    } else if (distance <= 20 && !_announcedThresholds.contains('20')) {
+      _announcedThresholds.addAll({'20', '40'});
+      TtsService().speak('잠시 후 $action하세요', channel: TtsChannel.navigation);
+    } else if (distance <= 40 && !_announcedThresholds.contains('40')) {
+      _announcedThresholds.add('40');
+      final msg = serverInstruction.isNotEmpty ? serverInstruction : '잠시 후 $action하세요';
+      TtsService().speak(msg, channel: TtsChannel.navigation);
+    }
+  }
+
+  // 길안내 시작 시 overview 안내 (방향 + 예상 시간 + 첫 step)
+  void speakStartOverview({
+    required String? startDirection,
+    required int totalTime,
+    required int firstStepDistance,
+    required DirectionType firstStepDirection,
+    required String firstStepInstruction,
+  }) {
+    reset();
+    final dirMsg = startDirection != null
+        ? '$startDirection 방향으로 출발합니다'
+        : '길안내를 시작합니다';
+
+    final timeStr = totalTime >= 60
+        ? '${totalTime ~/ 60}시간${totalTime % 60 == 0 ? '' : ' ${totalTime % 60}분'}'
+        : '$totalTime분';
+
+    final stepMsg = firstStepInstruction.isNotEmpty
+        ? firstStepInstruction
+        : '$firstStepDistance미터 앞에서 ${_actionText(firstStepDirection)}하세요';
+
+    TtsService().speak(
+      '$dirMsg. 약 $timeStr 소요됩니다. $stepMsg',
+      interrupt: true,
+      channel: TtsChannel.navigation,
+    );
+  }
+
+  void speakArrival() {
+    TtsService().speak('목적지에 도착했습니다', interrupt: true, channel: TtsChannel.navigation);
+  }
+
+  String _actionText(DirectionType direction) {
+    return switch (direction) {
+      DirectionType.left => '좌회전',
+      DirectionType.right => '우회전',
+      DirectionType.crosswalk => '횡단보도를 이용',
+      DirectionType.straight => '직진',
+    };
+  }
+}

--- a/frontend/lib/service/navigation_tts_service.dart
+++ b/frontend/lib/service/navigation_tts_service.dart
@@ -39,7 +39,7 @@ class NavigationTtsService {
     }
   }
 
-  // 길안내 시작 시 overview 안내 (방향 + 예상 시간 + 첫 step)
+  // 길안내 시작 시 overview 안내: 총 N분 → 방향 출발 → N미터 앞에서 ~
   void speakStartOverview({
     required String? startDirection,
     required int totalTime,
@@ -48,23 +48,39 @@ class NavigationTtsService {
     required String firstStepInstruction,
   }) {
     reset();
-    final dirMsg = startDirection != null
-        ? '$startDirection 방향으로 출발합니다'
-        : '길안내를 시작합니다';
+    // 현재 거리 내 임계값 마킹 → overview 후 speakDistance 중복 방지
+    _markDistanceAnnounced(firstStepDistance);
 
     final timeStr = totalTime >= 60
         ? '${totalTime ~/ 60}시간${totalTime % 60 == 0 ? '' : ' ${totalTime % 60}분'}'
         : '$totalTime분';
 
-    final stepMsg = firstStepInstruction.isNotEmpty
-        ? firstStepInstruction
-        : '$firstStepDistance미터 앞에서 ${_actionText(firstStepDirection)}하세요';
+    final dirMsg = startDirection != null
+        ? '$startDirection 방향으로 출발하세요'
+        : '길안내를 시작합니다';
 
     TtsService().speak(
-      '$dirMsg. 약 $timeStr 소요됩니다. $stepMsg',
+      '총 $timeStr 소요됩니다. $dirMsg. $firstStepDistance미터 앞에서 ${_actionText(firstStepDirection)}하세요',
       interrupt: true,
       channel: TtsChannel.navigation,
     );
+  }
+
+  // overview 종료 후 step[0] 서버 안내문 자동 재생 (큐 삽입)
+  void speakAfterOverview(String instruction) {
+    if (instruction.isEmpty) return;
+    // _isSpeaking = true (overview 재생 중) → pending 큐에 삽입 → overview 완료 시 자동 재생
+    TtsService().speak(instruction, interrupt: false, channel: TtsChannel.navigation);
+  }
+
+  void _markDistanceAnnounced(int distance) {
+    if (distance <= 8) {
+      _announcedThresholds.addAll({'8', '20', '40'});
+    } else if (distance <= 20) {
+      _announcedThresholds.addAll({'20', '40'});
+    } else if (distance <= 40) {
+      _announcedThresholds.add('40');
+    }
   }
 
   void speakArrival() {

--- a/frontend/lib/service/tts_service.dart
+++ b/frontend/lib/service/tts_service.dart
@@ -1,20 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 
-/// =======================================================
-/// TtsService
-///
-/// 역할:
-///   - 장애물 탐지 결과(guideText)를 한국어 음성으로 출력
-///   - alertLevel 기반 우선순위 처리
-///     · high   → 진행 중인 음성을 중단하고 즉시 출력
-///     · medium → 현재 말하는 중이 아닐 때만 출력
-///     · low    → 현재 말하는 중이 아닐 때만 출력
-///
-/// 호출 위치:
-///   - DetectionScreen: 탐지 이벤트 수신 시 speak() 호출
-///   - DetectionScreen: 탐지 중지 시 stop() 호출
-/// =======================================================
+enum TtsChannel { detection, navigation }
+
 class TtsService {
   static final TtsService _instance = TtsService._internal();
   factory TtsService() => _instance;
@@ -25,9 +13,10 @@ class TtsService {
   bool _isSpeaking = false;
   bool _voiceGuidanceEnabled = true;
 
-  static const double defaultSpeechRate = 1.0;
+  // navigation 채널 전용 큐 (detection 중일 때 대기)
+  String? _pendingNavMessage;
 
-  // ─── 초기화 ────────────────────────────────────────────────────────────────
+  static const double defaultSpeechRate = 1.0;
 
   Future<void> _init() async {
     if (_initialized) return;
@@ -45,6 +34,13 @@ class TtsService {
     _tts.setCompletionHandler(() {
       _isSpeaking = false;
       debugPrint('🔊 [TTS] 음성 출력 완료');
+      // detection 종료 후 대기 중인 nav 안내 재생
+      final pending = _pendingNavMessage;
+      if (pending != null) {
+        _pendingNavMessage = null;
+        debugPrint('🔊 [TTS] 대기 nav 안내 출력: $pending');
+        _tts.speak(pending);
+      }
     });
 
     _tts.setCancelHandler(() {
@@ -61,48 +57,60 @@ class TtsService {
     debugPrint('🔊 [TTS] 초기화 완료');
   }
 
-  // ─── 음성 출력 ─────────────────────────────────────────────────────────────
-
-  /// guideText를 음성으로 출력한다.
-  ///
-  /// [interrupt] = true  → 진행 중인 음성을 중단하고 즉시 출력 (high alert용)
-  /// [interrupt] = false → 이미 말하는 중이면 스킵 (medium / low alert용)
   void setVoiceGuidanceEnabled(bool enabled) {
     _voiceGuidanceEnabled = enabled;
     debugPrint('🔊 [TTS] 음성 안내 ${enabled ? '켜짐' : '꺼짐'}');
   }
 
-  Future<void> speak(String text, {bool interrupt = false}) async {
-    if (text.isEmpty) return;
-    if (!_voiceGuidanceEnabled) return;
-
+  /// 우선순위 규칙:
+  ///
+  ///   상황                         동작
+  ///   ─────────────────────────────────────────────────────────────────
+  ///   nav step전환 / ≤8m           detection 포함 모든 음성 끊고 즉시 출력
+  ///   nav ≤20m / ≤40m             detection 말하는 중이면 큐 대기 → 완료 후 출력
+  ///   detection high alert         nav 말하는 중이어도 끊고 즉시 출력
+  ///   detection medium / low       말하는 중이면 스킵
+  ///   목적지 도착                   detection 끊고 즉시 출력
+  ///   ─────────────────────────────────────────────────────────────────
+  ///   interrupt=true           → 채널 무관 현재 음성 끊고 즉시 출력
+  ///   interrupt=false, nav     → detection 말하는 중이면 큐에 저장 후 완료 시 출력
+  ///   interrupt=false, detect  → 말하는 중이면 스킵
+  Future<void> speak(
+    String text, {
+    bool interrupt = false,
+    TtsChannel channel = TtsChannel.detection,
+  }) async {
+    if (text.isEmpty || !_voiceGuidanceEnabled) return;
     await _init();
 
     if (_isSpeaking) {
       if (interrupt) {
+        _pendingNavMessage = null;
         await _tts.stop();
+      } else if (channel == TtsChannel.navigation) {
+        // detection 말하는 중 → 대기
+        _pendingNavMessage = text;
+        debugPrint('🔊 [TTS] nav 안내 대기 중: $text');
+        return;
       } else {
+        // detection → nav 말하는 중이면 스킵
         debugPrint('🔊 [TTS] 출력 중 — 스킵: $text');
         return;
       }
     }
 
+    _pendingNavMessage = null;
     debugPrint('🔊 [TTS] 출력: $text');
     await _tts.speak(text);
   }
 
-  // ─── 속도 조절 ─────────────────────────────────────────────────────────────
-
-  /// 음성 속도를 변경한다. 범위: 0.5(느림) ~ 5.0(빠름)
   Future<void> setSpeechRate(double rate) async {
     await _init();
     await _tts.setSpeechRate(rate.clamp(0.5, 5.0));
   }
 
-  // ─── 중지 ──────────────────────────────────────────────────────────────────
-
-  /// 진행 중인 음성 출력을 즉시 중단한다.
   Future<void> stop() async {
+    _pendingNavMessage = null;
     await _tts.stop();
     _isSpeaking = false;
     debugPrint('🔊 [TTS] 중지');

--- a/frontend/lib/service/tts_service.dart
+++ b/frontend/lib/service/tts_service.dart
@@ -100,6 +100,7 @@ class TtsService {
     }
 
     _pendingNavMessage = null;
+    _isSpeaking = true;
     debugPrint('🔊 [TTS] 출력: $text');
     await _tts.speak(text);
   }


### PR DESCRIPTION
## 📎 Issue 번호
#7 #8

## 📄 작업 내용 요약
 - **NavigationTtsService 추가**: 길찾기 전용 TTS 서비스 분리
    - overview: 총 소요시간 → 출발 방향 → 첫 step 거리+방향 순으로 안내                                                                                                                                     
    - overview 종료 후 step[0] 서버 안내문 자동 재생 (큐 방식)                                                                                                                                            
    - 거리 임계값 안내: ≤40m(서버 안내문) → ≤20m(잠시 후) → ≤8m(즉시 행동)                                                                                                                                  
    - step 전환 시 다음 step 즉시 안내, 목적지 도착 안내
    - 재탐색 시 overview 없이 새 경로 첫 step 바로 안내                                                                                                                                                     
                                                                                                                                                                                                            
  - **TtsService 채널 우선순위 처리**                                                                                                                                                                       
    - nav urgent (step전환·≤8m·도착): detection 포함 모든 음성 끊고 즉시 출력                                                                                                                               
    - nav 일반 (≤20m·≤40m·overview후 step): detection 중 큐 대기 → 완료 후 재생                                                                                                                             
    - detection high alert: nav 중이어도 끊고 즉시 출력                                                                                                                                                     
    - detection medium/low: 말하는 중이면 스킵

## ✅ 체크리스트
- [ ] 길찾기 시작 시 overview TTS 출력 확인 (방향 + 소요시간 + 첫 step)
- [ ] step 접근 시 40m → 20m → 8m 순차 안내 확인                       
- [ ] step 통과 시 다음 step TTS 즉시 출력 확인 
- [ ] 목적지 도착 시 "목적지에 도착했습니다" 출력 확인
- [ ] 재탐색 후 overview 없이 첫 step 바로 안내 확인  
- [ ] detection 탐지 중 nav 20m/40m 안내가 큐 대기 후 재생되는지 확인
- [ ] detection high alert가 nav 안내 중에도 즉시 출력되는지 확인