### PR TITLE
[FEAT] 역지오코딩 source 7종 대응 및 retry 로직 개선

### DIFF
--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'dart:async';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/common/theme/color_collection.dart';
@@ -47,6 +47,8 @@ class _NavigationScreenState extends State<NavigationScreen> {
   Timer? _debounce;
   Timer? _reverseGeocodeRetry;
   Position? _currentPosition;
+  int _fallbackCount = 0;
+  static const int _maxFallbackCount = 3;
   bool isLoading = false;
   List<SavedPlace> _savedPlaces = [];
   List<Map<String, dynamic>> _recentPlaces = [];
@@ -107,28 +109,51 @@ class _NavigationScreenState extends State<NavigationScreen> {
   }
 
   Future<void> _fetchAddress(Position position) async {
-    final address = await PlaceService.reverseGeocode(
+    _fallbackCount = 0;
+    _reverseGeocodeRetry?.cancel();
+
+    final result = await PlaceService.reverseGeocode(
       lat: position.latitude,
       lng: position.longitude,
     );
     if (!mounted) return;
-    if (address != null) {
-      _reverseGeocodeRetry?.cancel();
-      setState(() => currentLocation = address);
-    } else {
-      _reverseGeocodeRetry?.cancel();
-      _reverseGeocodeRetry = Timer.periodic(const Duration(seconds: 5), (_) async {
-        final retryAddress = await PlaceService.reverseGeocode(
-          lat: position.latitude,
-          lng: position.longitude,
-        );
-        if (!mounted) return;
-        if (retryAddress != null) {
-          _reverseGeocodeRetry?.cancel();
-          setState(() => currentLocation = retryAddress);
-        }
-      });
+
+    if (_applyGeocodeResult(result)) return;
+
+    // exactAddress 미획득 → 5초마다 재시도
+    _reverseGeocodeRetry = Timer.periodic(const Duration(seconds: 5), (_) async {
+      final retryResult = await PlaceService.reverseGeocode(
+        lat: _currentPosition?.latitude ?? position.latitude,
+        lng: _currentPosition?.longitude ?? position.longitude,
+      );
+      if (!mounted) {
+        _reverseGeocodeRetry?.cancel();
+        return;
+      }
+      if (_applyGeocodeResult(retryResult)) {
+        _reverseGeocodeRetry?.cancel();
+      }
+    });
+  }
+
+  /// 결과 적용 후 retry 종료 여부 반환
+  bool _applyGeocodeResult(ReverseGeocodeResult? result) {
+    if (result == null) return false;
+
+    if (result.source == ReverseGeocodeSource.exactAddress) {
+      setState(() => currentLocation = result.address);
+      return true;
     }
+
+    if (result.source == ReverseGeocodeSource.nearestPlace) {
+      _fallbackCount++;
+      setState(() => currentLocation = result.address);
+      // nearestPlace 3회 수신 시 최선값으로 확정
+      if (_fallbackCount >= _maxFallbackCount) return true;
+    }
+
+    // regionAddress → 표시 안 하고 계속 retry
+    return false;
   }
 
   /// destinationController의 listener 해제

--- a/frontend/lib/service/place_service.dart
+++ b/frontend/lib/service/place_service.dart
@@ -3,11 +3,24 @@ import 'package:flutter/cupertino.dart';
 import 'package:http/http.dart' as http;
 import 'package:safepath/service/token_storage.dart';
 
+enum ReverseGeocodeSource {
+  exactAddress,   // KAKAO_ROAD_ADDRESS, KAKAO_JIBUN_ADDRESS, NAVER_ROAD_ADDRESS, NAVER_JIBUN_ADDRESS
+  nearestPlace,   // KAKAO_NEAREST_PLACE
+  regionAddress,  // KAKAO_REGION_ADDRESS
+}
+
+class ReverseGeocodeResult {
+  final String address;
+  final ReverseGeocodeSource source;
+
+  const ReverseGeocodeResult({required this.address, required this.source});
+}
+
 class PlaceService {
   static const String _baseUrl = String.fromEnvironment('BASE_URL');
 
   /// 역지오코딩 API
-  static Future<String?> reverseGeocode({
+  static Future<ReverseGeocodeResult?> reverseGeocode({
     required double lat,
     required double lng,
   }) async {
@@ -24,9 +37,24 @@ class PlaceService {
 
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
+        if (data['success'] == true) {
+          final d = data['data'];
+          final address = d['address'] as String? ?? '';
+          final sourceStr = d['source'] as String? ?? '';
+          debugPrint('🟡 [Place] reverseGeocode source: $sourceStr');
 
-        if (data['success']) {
-          return data['data']['roadAddress'] ?? data['data']['address'];
+          if (sourceStr == 'KAKAO_ADDRESS_NOT_FOUND' || address.isEmpty) return null;
+
+          final source = switch (sourceStr) {
+            'KAKAO_ROAD_ADDRESS' ||
+            'KAKAO_JIBUN_ADDRESS' ||
+            'NAVER_ROAD_ADDRESS' ||
+            'NAVER_JIBUN_ADDRESS' => ReverseGeocodeSource.exactAddress,
+            'KAKAO_NEAREST_PLACE' => ReverseGeocodeSource.nearestPlace,
+            _ => ReverseGeocodeSource.regionAddress,
+          };
+
+          return ReverseGeocodeResult(address: address, source: source);
         }
       }
 


### PR DESCRIPTION
## 📎 Issue 번호
#96 

## 📄 작업 내용 요약
- 백엔드 reverse-geocode API의 `source` 값이 3종에서 7종으로 확장됨에 따라 클라이언트 매핑 로직 업데이트                                                                                                  
- `ReverseGeocodeSource` enum을 의미 단위로 재설계하여 여러 source 문자열을 동일한 처리 흐름으로 묶음
- `_fetchAddress` retry 로직에 source 기반 분기 및 nearestPlace 최대 횟수 제한(3회) 추가
- 현재 위치 정확도 확보 로직:                                                                                                                                                                             
    - `exactAddress` 수신 시 → 즉시 표시하고 재시도 중단 (가장 정확한 상태)                                                                                                                                 
    - `nearestPlace` 수신 시 → 주소를 표시하되 횟수를 카운트하고, 3회 연속 수신되면 최선값으로 확정하여 재시도 중단                                                                                         
    - `regionAddress` 수신 시 → 행정동/법정동 수준의 부정확한 주소이므로 표시하지 않고 5초마다 재시도 유지                                                                                                  
    - `null`(KAKAO_ADDRESS_NOT_FOUND / 빈 주소) 수신 시 → 재시도 유지                                                                                                                                       
    - 재시도 시 초기 위치가 아닌 `_currentPosition` 최신 좌표를 사용하여 이동 중에도 정확한 주소 획득 가능

| source 값 | enum 매핑 | 주소 표시 | retry 종료 |
|---|---|---|---|
| `KAKAO_ROAD_ADDRESS` | `exactAddress` | O | O (즉시) |
| `KAKAO_JIBUN_ADDRESS` | `exactAddress` | O | O (즉시) |
| `NAVER_ROAD_ADDRESS` | `exactAddress` | O | O (즉시) |
| `NAVER_JIBUN_ADDRESS` | `exactAddress` | O | O (즉시) |
| `KAKAO_NEAREST_PLACE` | `nearestPlace` | O | O (3회 누적 시 확정) |
| `KAKAO_REGION_ADDRESS` | `regionAddress` | X | X (5초마다 재시도) |
| `KAKAO_ADDRESS_NOT_FOUND` | `null 반환` | X | X (5초마다 재시도) |

## ✅ 체크리스트
- [x] 도로명 주소(`KAKAO_ROAD_ADDRESS`)가 내려올 때 현재 위치가 즉시 표시되고 재시도 없음                                                                                                                 
- [x] 지번 주소(`KAKAO_JIBUN_ADDRESS`) / 네이버 주소(`NAVER_*`) 동일하게 동작
- [x] `KAKAO_NEAREST_PLACE` 응답 시 주소가 표시되고, 3회 연속 수신 후 재시도 중단                                                                                                                         
- [x] `KAKAO_REGION_ADDRESS` 응답 시 현재 위치 문구 변경 없이 재시도 지속                                                                                                                                 
- [x] `KAKAO_ADDRESS_NOT_FOUND` 응답 시 null 처리되어 재시도 지속
