### PR TITLE
[FEAT/FIX] 현재 위치 실시간 갱신 및 길안내 step 완수 버그 수정

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -232,20 +232,25 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
 
     if (distance < _minDistanceToStep) _minDistanceToStep = distance;
 
+    // pass-through 완수: 10m 이내 진입 후 최근접 지점에서 8m 이상 멀어지면 완수
+    // (distance >= 10m 분기보다 먼저 체크해야 함 — minDist + 8m >= 10m 인 경우를 커버)
+    if (_hasBeenOutsideThreshold &&
+        _minDistanceToStep < _arrivalThresholdMeters &&
+        distance > _minDistanceToStep + _passThroughOffsetMeters) {
+      setState(() {
+        _currentStepIndex++;
+        _hasBeenOutsideThreshold = false;
+        _minDistanceToStep = double.infinity;
+        _debugDistance = null;
+      });
+      _checkDeviation(position);
+      return;
+    }
+
     if (distance >= _arrivalThresholdMeters) {
       _hasBeenOutsideThreshold = true;
-    } else if (_hasBeenOutsideThreshold) {
-      // pass-through: 최근접 거리에서 _passThroughOffsetMeters 이상 멀어졌을 때 완수
-      if (distance > _minDistanceToStep + _passThroughOffsetMeters) {
-        setState(() {
-          _currentStepIndex++;
-          _hasBeenOutsideThreshold = false;
-          _minDistanceToStep = double.infinity;
-          _debugDistance = null;
-        });
-      }
-    } else {
-      // 처음부터 threshold 이내 → 이미 지난 step으로 간주하고 skip
+    } else if (!_hasBeenOutsideThreshold) {
+      // 처음부터 10m 이내 → 이미 지난 step으로 간주하고 skip
       setState(() {
         _currentStepIndex++;
         _minDistanceToStep = double.infinity;

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -46,9 +46,8 @@ class _NavigationScreenState extends State<NavigationScreen> {
   bool _isLoadingMore = false;
   Timer? _debounce;
   Timer? _reverseGeocodeRetry;
+  StreamSubscription<Position>? _positionStream;
   Position? _currentPosition;
-  int _fallbackCount = 0;
-  static const int _maxFallbackCount = 3;
   bool isLoading = false;
   List<SavedPlace> _savedPlaces = [];
   List<Map<String, dynamic>> _recentPlaces = [];
@@ -102,6 +101,19 @@ class _NavigationScreenState extends State<NavigationScreen> {
       if (!mounted) return;
       _currentPosition = position;
       await _fetchAddress(position);
+
+      // 초기 위치 획득 후 20m 이상 이동 시 위치·주소 갱신
+      _positionStream?.cancel();
+      _positionStream = Geolocator.getPositionStream(
+        locationSettings: AndroidSettings(
+          accuracy: LocationAccuracy.best,
+          distanceFilter: 20,
+        ),
+      ).listen((pos) {
+        if (!mounted) return;
+        _currentPosition = pos;
+        _fetchAddress(pos);
+      });
     } catch (e) {
       debugPrint('🔴 위치 초기화 실패: $e');
       if (mounted) setState(() => currentLocation = '현재 위치 불러오는 중...');
@@ -109,7 +121,6 @@ class _NavigationScreenState extends State<NavigationScreen> {
   }
 
   Future<void> _fetchAddress(Position position) async {
-    _fallbackCount = 0;
     _reverseGeocodeRetry?.cancel();
 
     final result = await PlaceService.reverseGeocode(
@@ -146,12 +157,10 @@ class _NavigationScreenState extends State<NavigationScreen> {
     }
 
     if (result.source == ReverseGeocodeSource.nearestPlace) {
-      _fallbackCount++;
       setState(() => currentLocation = result.address);
-      // nearestPlace 3회 수신 시 최선값으로 확정
-      if (_fallbackCount >= _maxFallbackCount) return true;
     }
 
+    // nearestPlace는 표시하되 exactAddress를 받을 때까지 retry 유지
     // regionAddress → 표시 안 하고 계속 retry
     return false;
   }
@@ -162,6 +171,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
     destinationController.dispose();
     _debounce?.cancel();
     _reverseGeocodeRetry?.cancel();
+    _positionStream?.cancel();
     super.dispose();
   }
 
@@ -214,6 +224,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
     SoundEffectService().play(SoundEffect.actionStart);
     VibrationService().vibrate(VibrationEffect.actionStart);
 
+    _positionStream?.cancel();
     setState(() => isLoading = true);
 
     try {


### PR DESCRIPTION
## 📎 Issue 번호
#96

## 📄 작업 내용 요약
- 목적지 설정 화면에서 현재 위치가 화면 진입 시 한 번만 갱신되던 문제 개선                                                                                                                                
- 길안내 중 step 기준점(8m)을 넘었음에도 다음 step으로 넘어가지 않던 버그 수정


## ✅ 체크리스트
- [x] 화면 진입 후 이동 시 현재 위치 주소가 실시간으로 갱신되는지 확인                                                                                                                                    
- [x] `nearestPlace` 응답 수신 시 주소가 표시된 채로 retry가 유지되는지 확인
- [x] 길안내 시작 시 실제 출발 위치가 출발지로 설정되는지 확인                                                                                                                                            
- [x] step 기준점 근처를 통과할 때 다음 step으로 정상적으로 넘어가는지 확인                                                                                                                               
- [x] GPS 정확도 20m 초과 시 위치 업데이트 무시되는지 확인
