### PR TITLE
[FEAT] 장애물 안내 문장길이 옵션 추가

### DIFF
--- a/ai/app/api/analyze.py
+++ b/ai/app/api/analyze.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
+
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 import logging
 import time
+
 import cv2
 import numpy as np
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
@@ -19,12 +21,32 @@ router = APIRouter(prefix="/api", tags=["analyze"])
 # user별 frame index. tracking/cooldown 판단에 사용.
 _user_frame_counter: dict[str, int] = defaultdict(int)
 
+VALID_SENTENCE_LENGTHS = {"SHORT", "MEDIUM", "LONG"}
+
+
+def normalize_sentence_length(sentence_length: str | None) -> str:
+    """
+    백엔드에서 넘어온 sentence_length 값을 정규화한다.
+    허용값: SHORT, MEDIUM, LONG
+    잘못된 값이 오면 기본값 MEDIUM 사용.
+    """
+    if not sentence_length:
+        return "MEDIUM"
+
+    value = str(sentence_length).strip().upper()
+
+    if value not in VALID_SENTENCE_LENGTHS:
+        return "MEDIUM"
+
+    return value
+
 
 def build_backend_event_payload(
     user_id: str,
     processed_at: str,
     processing_time_ms: int,
     gt: dict,
+    sentence_length: str,
 ) -> dict:
     """
     백엔드와 합의한 전송용 payload.
@@ -42,6 +64,7 @@ def build_backend_event_payload(
         "clock_direction": gt.get("clock_direction"),
         "distance": gt.get("distance"),
         "alert_level": gt.get("alert_level", "safe"),
+        "sentence_length": sentence_length,
     }
 
 
@@ -49,16 +72,19 @@ def build_backend_event_payload(
 async def analyze_image(
     user_id: str = Form(...),
     captured_at: str = Form(...),
+    sentence_length: str = Form("MEDIUM"),
     image: UploadFile = File(...),
 ):
     start_time = time.perf_counter()
+    sentence_length = normalize_sentence_length(sentence_length)
 
     logger.info(
-        "analyze request received | user_id=%s | filename=%s | content_type=%s | captured_at=%s",
+        "analyze request received | user_id=%s | filename=%s | content_type=%s | captured_at=%s | sentence_length=%s",
         user_id,
         image.filename,
         image.content_type,
         captured_at,
+        sentence_length,
     )
 
     # =========================================================
@@ -125,19 +151,24 @@ async def analyze_image(
             frame_bgr=frame_bgr,
             image_id=image_id,
             frame_idx=frame_idx,
+            sentence_length=sentence_length,
         )
 
         scene_json = result["scene_json"]
         gt = result["gt"]
         timings_ms = result.get("timings_ms", {})
 
+        # guide_builder에서 gt에 sentence_length를 넣지 않았더라도 응답 일관성 유지
+        gt["sentence_length"] = sentence_length
+
         logger.info(
-            "추론 완료 | user_id=%s | frame_idx=%d | det_count=%d | alert_level=%s | action=%s | guide_text=%s",
+            "추론 완료 | user_id=%s | frame_idx=%d | det_count=%d | alert_level=%s | action=%s | sentence_length=%s | guide_text=%s",
             user_id,
             frame_idx,
             result.get("det_count", 0),
             gt.get("alert_level"),
             gt.get("action"),
+            sentence_length,
             gt.get("voice_guide", ""),
         )
 
@@ -174,13 +205,15 @@ async def analyze_image(
                 processing_time_ms=processing_time_ms,
             )
             payload["alert_level"] = gt_alert_level
+            payload["sentence_length"] = sentence_length
 
             logger.warning(
-                "AI timeout | user_id=%s | frame_idx=%d | processing_time_ms=%d | alert_level=%s | gt=%s | timings_ms=%s",
+                "AI timeout | user_id=%s | frame_idx=%d | processing_time_ms=%d | alert_level=%s | sentence_length=%s | gt=%s | timings_ms=%s",
                 user_id,
                 frame_idx,
                 processing_time_ms,
                 gt_alert_level,
+                sentence_length,
                 gt,
                 timings_ms,
             )
@@ -191,6 +224,7 @@ async def analyze_image(
                 processed_at=processed_at,
                 processing_time_ms=processing_time_ms,
                 gt=gt,
+                sentence_length=sentence_length,
             )
 
     except Exception as exc:
@@ -216,13 +250,18 @@ async def analyze_image(
                 backend_url=BACKEND_GUIDE_EVENT_URL,
             )
             logger.info(
-                "백엔드 전송 성공 | user_id=%s | alert_level=%s | backend_url=%s",
+                "백엔드 전송 성공 | user_id=%s | alert_level=%s | sentence_length=%s | backend_url=%s",
                 user_id,
                 gt_alert_level,
+                sentence_length,
                 BACKEND_GUIDE_EVENT_URL,
             )
         except Exception as exc:
-            logger.warning("백엔드 /api/guide/event 전송 실패 (무시하고 계속) | user_id=%s | error=%s", user_id, exc)
+            logger.warning(
+                "백엔드 /api/guide/event 전송 실패 (무시하고 계속) | user_id=%s | error=%s",
+                user_id,
+                exc,
+            )
             backend_response = {"status": "failed", "reason": str(exc)}
     else:
         backend_response = {
@@ -238,6 +277,7 @@ async def analyze_image(
     return {
         "status": "forwarded" if should_send else "skipped",
         "saved_filename": save_filename,
+        "sentence_length": sentence_length,
         "scene_json": scene_json,
         "gt": gt,
         "timings_ms": timings_ms,

--- a/ai/app/services/guide_builder.py
+++ b/ai/app/services/guide_builder.py
@@ -82,6 +82,9 @@ WALKING_VIEW_HOURS = {9, 10, 11, 12, 1, 2, 3}
 # bbox 하단 영역 중 점자블록 mask와 5% 이상 겹치면 점자블록 위 장애물로 판단
 TACTILE_OVERLAP_THRESH = 0.05
 
+# 안내문 길이 옵션
+VALID_SENTENCE_LENGTHS = {"SHORT", "MEDIUM", "LONG"}
+
 # 서버 프로세스가 살아있는 동안 tracking/cooldown 유지
 track_history: dict[int, deque] = defaultdict(lambda: deque(maxlen=TRACK_HISTORY_LEN))
 last_announced_frame: dict[int, int] = {}
@@ -192,6 +195,102 @@ def horiz_region(x_ratio: float) -> str:
     if x_ratio < 2 / 3:
         return "center"
     return "right"
+
+
+# =========================================================
+# Sentence length / guide formatting
+# =========================================================
+def normalize_sentence_length(sentence_length: str | None) -> str:
+    if not sentence_length:
+        return "MEDIUM"
+
+    value = str(sentence_length).strip().upper()
+    if value not in VALID_SENTENCE_LENGTHS:
+        return "MEDIUM"
+
+    return value
+
+
+def opposite_detour_text(clock_direction: str | None) -> str:
+    """
+    위험 객체 방향을 기준으로 간단한 우회 방향을 정한다.
+    오른쪽에 위험이 있으면 왼쪽, 왼쪽에 위험이 있으면 오른쪽.
+    중앙이면 기본 오른쪽.
+    """
+    if not clock_direction:
+        return "오른쪽"
+
+    try:
+        hour = clock_to_int(clock_direction)
+    except Exception:
+        return "오른쪽"
+
+    if hour in {1, 2, 3}:
+        return "왼쪽"
+    if hour in {9, 10, 11}:
+        return "오른쪽"
+
+    return "오른쪽"
+
+
+def format_tactile_object_guide(
+    clock_direction: str,
+    object_ko: str,
+    sentence_length: str = "MEDIUM",
+    detour_text: str | None = None,
+) -> str:
+    """
+    점자블록 위 객체 안내문.
+    SHORT:  12시 점자블록 위 스쿠터.
+    MEDIUM: 주의. 12시 점자블록 위 스쿠터, 오른쪽 우회.
+    LONG:   주의. 12시 방향 점자블록 위에 스쿠터가 있습니다. 오른쪽으로 우회하세요.
+    """
+    sentence_length = normalize_sentence_length(sentence_length)
+    detour_text = detour_text or opposite_detour_text(clock_direction)
+
+    if sentence_length == "SHORT":
+        return f"{clock_direction} 점자블록 위 {object_ko}."
+
+    if sentence_length == "LONG":
+        return (
+            f"주의. {clock_direction} 방향 점자블록 위에 {jo_iga(object_ko)} 있습니다. "
+            f"{detour_text}으로 우회하세요."
+        )
+
+    return f"주의. {clock_direction} 점자블록 위 {object_ko}, {detour_text} 우회."
+
+
+def format_tactile_unknown_guide(
+    clock_direction: str,
+    sentence_length: str = "MEDIUM",
+) -> str:
+    sentence_length = normalize_sentence_length(sentence_length)
+    detour_text = opposite_detour_text(clock_direction)
+
+    if sentence_length == "SHORT":
+        return f"{clock_direction} 점자블록 가림."
+
+    if sentence_length == "LONG":
+        return (
+            f"주의. {clock_direction} 방향 점자블록 위에 장애물이 있거나 "
+            f"점자블록이 가려져 있습니다. {detour_text}으로 우회하세요."
+        )
+
+    return f"주의. {clock_direction} 점자블록 가림, {detour_text} 우회."
+
+
+def format_tactile_broken_guide(
+    sentence_length: str = "MEDIUM",
+) -> str:
+    sentence_length = normalize_sentence_length(sentence_length)
+
+    if sentence_length == "SHORT":
+        return "전방 점자블록 끊김."
+
+    if sentence_length == "LONG":
+        return "주의. 전방 점자블록이 끊겨 있습니다. 주변 보행로를 확인하며 천천히 이동하세요."
+
+    return "주의. 전방 점자블록 끊김, 천천히 이동."
 
 
 # =========================================================
@@ -763,7 +862,10 @@ def build_scene_from_model_outputs(
     seg_result: Any,
     depth_m: np.ndarray,
     det_class_names: dict[int, str],
+    sentence_length: str = "MEDIUM",
 ) -> dict[str, Any]:
+    sentence_length = normalize_sentence_length(sentence_length)
+
     seg_info = analyze_segmentation(seg_result, img_w, img_h)
     zones = analyze_zones(depth_m)
 
@@ -882,7 +984,13 @@ def build_scene_from_model_outputs(
         "_zones": zones,
     }
 
-    gt = build_voice_guide(scene, frame_idx, img_w, img_h)
+    gt = build_voice_guide(
+        scene=scene,
+        frame_idx=frame_idx,
+        img_w=img_w,
+        img_h=img_h,
+        sentence_length=sentence_length,
+    )
 
     # 내부 계산용 키 제거
     for obj in scene["objects"]:
@@ -971,21 +1079,39 @@ def compute_risk_score(obj: dict[str, Any], scene_img_area: float) -> float:
     return base + dist_bonus + size_bonus + view_bonus + path_bonus + road_penalty + approach_bonus + tactile_bonus
 
 
-def build_voice_guide(scene: dict[str, Any], frame_idx: int, img_w: int, img_h: int) -> dict[str, Any]:
+def build_voice_guide(
+    scene: dict[str, Any],
+    frame_idx: int,
+    img_w: int,
+    img_h: int,
+    sentence_length: str = "MEDIUM",
+) -> dict[str, Any]:
+    sentence_length = normalize_sentence_length(sentence_length)
+
     # 점자블록 위 장애물/가림/끊김은 일반 객체 안내보다 우선
-    tactile_gt = _decide_tactile_guide_once(scene, frame_idx)
+    tactile_gt = _decide_tactile_guide_once(
+        scene=scene,
+        frame_idx=frame_idx,
+        sentence_length=sentence_length,
+    )
     if tactile_gt is not None:
         tactile_gt["scene_info_added"] = []
+        tactile_gt["sentence_length"] = sentence_length
         tactile_gt["alert_level"] = alert_level_from_gt(tactile_gt)
         return tactile_gt
 
     gt = _decide_primary_guide(scene, frame_idx, img_w, img_h)
     gt = _append_scene_info(gt, scene, frame_idx)
+    gt["sentence_length"] = sentence_length
     gt["alert_level"] = alert_level_from_gt(gt)
     return gt
 
 
-def _decide_tactile_guide_once(scene: dict[str, Any], frame_idx: int) -> dict[str, Any] | None:
+def _decide_tactile_guide_once(
+    scene: dict[str, Any],
+    frame_idx: int,
+    sentence_length: str = "MEDIUM",
+) -> dict[str, Any] | None:
     """
     점자블록 관련 위험은 최초 1회만 안내한다.
 
@@ -993,6 +1119,7 @@ def _decide_tactile_guide_once(scene: dict[str, Any], frame_idx: int) -> dict[st
     2. detection 객체는 없지만 점자블록 mask가 중간에서 끊기거나 가려짐
     3. 점자블록이 하단에는 보이지만 전방으로 이어지지 않음
     """
+    sentence_length = normalize_sentence_length(sentence_length)
     objects = scene["objects"]
 
     # 1. detection 객체가 점자블록 위에 있는 경우
@@ -1015,6 +1142,12 @@ def _decide_tactile_guide_once(scene: dict[str, Any], frame_idx: int) -> dict[st
         ko = to_ko(primary["class"])
         direction = primary["clock_direction"]
 
+        voice = format_tactile_object_guide(
+            clock_direction=direction,
+            object_ko=ko,
+            sentence_length=sentence_length,
+        )
+
         mark_scene_announced_once("tactile_blocked_by_object", frame_idx)
 
         return _make_gt(
@@ -1022,7 +1155,7 @@ def _decide_tactile_guide_once(scene: dict[str, Any], frame_idx: int) -> dict[st
             "caution",
             2,
             f"{direction} 방향 점자블록 위 {ko} 감지",
-            f"주의. {direction} 방향 점자블록 위에 {jo_iga(ko)} 있습니다.",
+            voice,
         )
 
     tactile_block = scene.get("tactile_block", {})
@@ -1032,6 +1165,12 @@ def _decide_tactile_guide_once(scene: dict[str, Any], frame_idx: int) -> dict[st
     if tactile_status == "blocked_or_occluded":
         if not is_scene_announced_once("tactile_blocked_or_occluded"):
             direction = tactile_block.get("clock_direction") or "12시"
+
+            voice = format_tactile_unknown_guide(
+                clock_direction=direction,
+                sentence_length=sentence_length,
+            )
+
             mark_scene_announced_once("tactile_blocked_or_occluded", frame_idx)
 
             return {
@@ -1045,12 +1184,14 @@ def _decide_tactile_guide_once(scene: dict[str, Any], frame_idx: int) -> dict[st
                 "action": "caution",
                 "priority": 2,
                 "reason": "점자블록 위 장애물 또는 가림 감지",
-                "voice_guide": f"주의. {direction} 방향 점자블록 위에 장애물이 있거나 점자블록이 가려져 있습니다.",
+                "voice_guide": voice,
             }
 
     # 3. 점자블록 끊김
     if tactile_status == "broken":
         if not is_scene_announced_once("tactile_broken"):
+            voice = format_tactile_broken_guide(sentence_length)
+
             mark_scene_announced_once("tactile_broken", frame_idx)
 
             return {
@@ -1064,7 +1205,7 @@ def _decide_tactile_guide_once(scene: dict[str, Any], frame_idx: int) -> dict[st
                 "action": "caution",
                 "priority": 2,
                 "reason": "전방 점자블록 끊김",
-                "voice_guide": "주의. 전방 점자블록이 끊겨 있습니다.",
+                "voice_guide": voice,
             }
 
     return None
@@ -1374,6 +1515,7 @@ def build_backend_payload(
         "clock_direction": gt.get("clock_direction"),
         "distance": gt.get("distance"),
         "alert_level": gt.get("alert_level", "safe"),
+        "sentence_length": gt.get("sentence_length", "MEDIUM"),
     }
 
 

--- a/ai/app/services/inference.py
+++ b/ai/app/services/inference.py
@@ -198,6 +198,7 @@ def run_single_image_inference(
     frame_bgr: np.ndarray,
     image_id: str | None = None,
     frame_idx: int = 0,
+    sentence_length: str = "MEDIUM",
 ) -> dict[str, Any]:
     """Run the integrated pipeline for a single frame.
 
@@ -266,6 +267,7 @@ def run_single_image_inference(
 
     # =====================================================
     # 4. Scene + guide build
+    # sentence_length를 guide_builder까지 전달
     # =====================================================
     t0 = time.perf_counter()
     packed = build_scene_from_model_outputs(
@@ -277,6 +279,7 @@ def run_single_image_inference(
         seg_result=seg_result,
         depth_m=depth_m,
         det_class_names=det_model.names,
+        sentence_length=sentence_length,
     )
     timings["scene_guide_build"] = (time.perf_counter() - t0) * 1000
 
@@ -288,6 +291,9 @@ def run_single_image_inference(
         "scene": packed["scene"],
     }
     gt = packed["gt"]
+
+    # 혹시 guide_builder에서 sentence_length를 gt에 넣지 않았을 경우 대비
+    gt["sentence_length"] = str(sentence_length).strip().upper()
 
     det_count = len(scene_json["scene"].get("objects", []))
 


### PR DESCRIPTION
## 📎 Issue 번호
#90 

## 📄 작업 내용 요약
- `/api/analyze` 요청에서 `sentence_length` 값을 입력받도록 수정
- `sentence_length` 값을 `analyze.py → inference.py → guide_builder.py` 흐름으로 전달하도록 반영
- `SHORT`, `MEDIUM`, `LONG` 옵션에 따라 장애물 안내 문장이 다르게 생성되도록 템플릿 추가
- 잘못된 `sentence_length` 값이 들어오거나 값이 없을 경우 기본값 `MEDIUM`으로 처리
- 생성된 안내 문장과 적용된 `sentence_length` 값을 Swagger 응답 및 백엔드 전송 payload에서 확인할 수 있도록 수정

## ✅ 체크리스트
- [x] `/api/analyze` 요청에서 `sentence_length` 값을 입력받을 수 있다.
- [x] `sentence_length` 값은 `SHORT`, `MEDIUM`, `LONG` 중 하나로 처리된다.
- [x] 잘못된 값이 들어오거나 값이 없으면 기본값 `MEDIUM`으로 처리된다.
- [x] `sentence_length` 값이 `analyze.py`에서 `inference.py`로 전달된다.
- [x] `sentence_length` 값이 `inference.py`에서 `guide_builder.py`로 전달된다.
- [x] `SHORT` 옵션에서는 핵심 위험 정보만 포함한 짧은 안내문이 생성된다.
- [x] `MEDIUM` 옵션에서는 주의 문구와 우회 방향을 포함한 짧은 명사형 안내문이 생성된다.
- [x] `LONG` 옵션에서는 완전한 문장 형태의 상세 안내문이 생성된다.
- [x] 백엔드 전송 payload 또는 Swagger 응답에서 적용된 `sentence_length` 값을 확인할 수 있다.

## 💬 리뷰 요청 사항
