### PR TITLE
[FEAT/FIX] 설정 페이지 UX 및 TTS 안내 개선

### DIFF
--- a/frontend/lib/features/settings/settings_info_widget.dart
+++ b/frontend/lib/features/settings/settings_info_widget.dart
@@ -43,7 +43,7 @@ class _InfoRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: item.label,
+      label: '${item.label}, 화면으로 이동',
       excludeSemantics: true,
       child: InkWell(
         onTap: item.onTap == null

--- a/frontend/lib/features/settings/settings_notification_widget.dart
+++ b/frontend/lib/features/settings/settings_notification_widget.dart
@@ -191,7 +191,13 @@ class _ToggleRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
-      label: '$label: ${value ? '켜짐' : '꺼짐'}. $description',
+      toggled: value,
+      label: '$label, $description',
+      onTap: () {
+        SoundEffectService().play(SoundEffect.buttonTap);
+        VibrationService().vibrate(VibrationEffect.buttonTap);
+        onChanged(!value);
+      },
       excludeSemantics: true,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),

--- a/frontend/lib/features/settings/settings_notification_widget.dart
+++ b/frontend/lib/features/settings/settings_notification_widget.dart
@@ -1,4 +1,5 @@
 ﻿import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'package:safepath/common/theme/color_collection.dart';
@@ -194,9 +195,11 @@ class _ToggleRow extends StatelessWidget {
       toggled: value,
       label: '$label, $description',
       onTap: () {
+        final newValue = !value;
         SoundEffectService().play(SoundEffect.buttonTap);
         VibrationService().vibrate(VibrationEffect.buttonTap);
-        onChanged(!value);
+        SemanticsService.announce('$label ${newValue ? '켜짐' : '꺼짐'}', TextDirection.ltr);
+        onChanged(newValue);
       },
       excludeSemantics: true,
       child: Padding(
@@ -238,7 +241,8 @@ class _ToggleRow extends StatelessWidget {
               value: value,
               onChanged: (v) {
                 SoundEffectService().play(SoundEffect.buttonTap);
-              VibrationService().vibrate(VibrationEffect.buttonTap);
+                VibrationService().vibrate(VibrationEffect.buttonTap);
+                SemanticsService.announce('$label ${v ? '켜짐' : '꺼짐'}', TextDirection.ltr);
                 onChanged(v);
               },
               activeThumbColor: Colors.white,

--- a/frontend/lib/features/settings/settings_profile_widget.dart
+++ b/frontend/lib/features/settings/settings_profile_widget.dart
@@ -16,14 +16,14 @@ class SettingsProfileWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: '프로필: $name. 프로필 편집',
+      label: '프로필: $name, 프로필 편집',
       excludeSemantics: true,
       child: InkWell(
         onTap: onTap == null
             ? null
             : () {
                 SoundEffectService().play(SoundEffect.buttonTap);
-              VibrationService().vibrate(VibrationEffect.buttonTap);
+                VibrationService().vibrate(VibrationEffect.buttonTap);
                 onTap!();
               },
         borderRadius: BorderRadius.circular(10),

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -135,6 +135,7 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
     setState(() => _vibration = next);
     VibrationService().setStrength(next);
     VibrationService().vibrate(VibrationEffect.buttonTap);
+    SemanticsService.announce('$next퍼센트로 변경됐습니다.', TextDirection.ltr);
     widget.onVibrationChanged?.call(next);
   }
 
@@ -143,6 +144,7 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
     setState(() => _vibration = next);
     VibrationService().setStrength(next);
     VibrationService().vibrate(VibrationEffect.buttonTap);
+    SemanticsService.announce('$next퍼센트로 변경됐습니다.', TextDirection.ltr);
     widget.onVibrationChanged?.call(next);
   }
 }

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -314,7 +314,8 @@ class _StepperRow extends StatelessWidget {
               onTap: onDecrease,
             ),
             Expanded(
-              child: ExcludeSemantics(
+              child: Semantics(
+                label: '현재 $label $displayValue',
                 child: Container(
                   height: 52,
                   alignment: Alignment.center,
@@ -324,12 +325,14 @@ class _StepperRow extends StatelessWidget {
                     borderRadius: BorderRadius.circular(10),
                     border: Border.all(color: ColorCollection.main, width: 2),
                   ),
-                  child: Text(
-                    displayValue,
-                    style: AppTextStyles.labelBold.copyWith(
-                      color: ColorCollection.main,
-                      fontWeight: FontWeight.w800,
-                      fontSize: 20,
+                  child: ExcludeSemantics(
+                    child: Text(
+                      displayValue,
+                      style: AppTextStyles.labelBold.copyWith(
+                        color: ColorCollection.main,
+                        fontWeight: FontWeight.w800,
+                        fontSize: 20,
+                      ),
                     ),
                   ),
                 ),

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -117,6 +117,7 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
   void _decreaseSpeed() {
     final next = (_ttsSpeed - _ttsStep).clamp(_ttsMin, _ttsMax);
     setState(() => _ttsSpeed = next);
+    VibrationService().vibrate(VibrationEffect.buttonTap);
     TtsService().setSpeechRate(next);
     TtsService().speak('${_speedLabel(next)}으로 변경됐습니다.', interrupt: true);
     widget.onGuidanceSpeedChanged?.call(next);
@@ -125,6 +126,7 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
   void _increaseSpeed() {
     final next = (_ttsSpeed + _ttsStep).clamp(_ttsMin, _ttsMax);
     setState(() => _ttsSpeed = next);
+    VibrationService().vibrate(VibrationEffect.buttonTap);
     TtsService().setSpeechRate(next);
     TtsService().speak('${_speedLabel(next)}으로 변경됐습니다.', interrupt: true);
     widget.onGuidanceSpeedChanged?.call(next);

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -310,8 +310,7 @@ class _StepperRow extends StatelessWidget {
               onTap: onDecrease,
             ),
             Expanded(
-              child: Semantics(
-                label: displayValue,
+              child: ExcludeSemantics(
                 child: Container(
                   height: 52,
                   alignment: Alignment.center,
@@ -321,14 +320,12 @@ class _StepperRow extends StatelessWidget {
                     borderRadius: BorderRadius.circular(10),
                     border: Border.all(color: ColorCollection.main, width: 2),
                   ),
-                  child: ExcludeSemantics(
-                    child: Text(
-                      displayValue,
-                      style: AppTextStyles.labelBold.copyWith(
-                        color: ColorCollection.main,
-                        fontWeight: FontWeight.w800,
-                        fontSize: 20,
-                      ),
+                  child: Text(
+                    displayValue,
+                    style: AppTextStyles.labelBold.copyWith(
+                      color: ColorCollection.main,
+                      fontWeight: FontWeight.w800,
+                      fontSize: 20,
                     ),
                   ),
                 ),

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -6,7 +6,12 @@ import 'package:safepath/service/tts_service.dart';
 import 'package:safepath/service/user_settings_service.dart';
 import 'package:safepath/service/vibration_service.dart';
 
-/// 안내 스타일 개인화 섹션 (슬라이더)
+/// 안내 스타일 개인화 섹션 (접근성 개선 버전)
+///
+/// 슬라이더 대신 탭 한 번으로 조작 가능한 버튼 UI 사용:
+///  - 안내 문장 길이 → 3개 세그먼트 버튼 (간결 / 보통 / 상세)
+///  - 안내 문장 빠르기 → − / + 스테퍼 (0.5배속 단위)
+///  - 진동 강도 → − / + 스테퍼 (10% 단위)
 class SettingsStyleWidget extends StatefulWidget {
   final UserSettings initialSettings;
   final void Function(MessageLength)? onSentenceLengthChanged;
@@ -26,31 +31,29 @@ class SettingsStyleWidget extends StatefulWidget {
 }
 
 class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
-  // TTS 속도: 0.5배속~5.0배속 → 슬라이더 0.0~1.0으로 변환
   static const double _ttsMin = 0.5;
   static const double _ttsMax = 5.0;
+  static const double _ttsStep = 0.5;
 
-  // 진동 강도: 0~100
-  static const int _vibrationMax = 100;
+  static const int _vibMax = 100;
+  static const int _vibStep = 10;
 
   late MessageLength _messageLength;
-  late double _vibrationStrength; // 슬라이더 0.0~1.0
-  late double _ttsSpeed; // 슬라이더 0.0~1.0
+  late double _ttsSpeed; // 0.5 ~ 5.0, step 0.5
+  late int _vibration; // 0 ~ 100, step 10
 
   @override
   void initState() {
     super.initState();
     _messageLength = widget.initialSettings.sentenceLength;
-    _vibrationStrength =
-        (widget.initialSettings.vibrationStrength / _vibrationMax).clamp(
-          0.0,
-          1.0,
-        );
-    final speed = widget.initialSettings.guidanceSpeed;
-    _ttsSpeed = ((speed - _ttsMin) / (_ttsMax - _ttsMin)).clamp(0.0, 1.0);
-  }
 
-  double get _ttsSpeedValue => _ttsMin + _ttsSpeed * (_ttsMax - _ttsMin);
+    final rawSpeed = widget.initialSettings.guidanceSpeed.clamp(_ttsMin, _ttsMax);
+    _ttsSpeed = (((rawSpeed - _ttsMin) / _ttsStep).round() * _ttsStep + _ttsMin)
+        .clamp(_ttsMin, _ttsMax);
+
+    final rawVib = widget.initialSettings.vibrationStrength.clamp(0, _vibMax);
+    _vibration = ((rawVib / _vibStep).round() * _vibStep).clamp(0, _vibMax);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -65,211 +68,163 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _SliderRow(
+          _SegmentedRow<MessageLength>(
             label: '안내 문장 길이',
-            value: _messageLength.sliderValue,
             description: '안내 메시지의 상세도를 조절합니다.',
-            divisions: 2,
-            tickLabels: const ['간결', '보통', '상세'],
-            valueFormatter: (_) => _messageLength.displayLabel,
-            onChanged: (v) =>
-                setState(() => _messageLength = MessageLength.fromSlider(v)),
-            onChangeEnd: (_) =>
-                widget.onSentenceLengthChanged?.call(_messageLength),
+            options: MessageLength.values,
+            selected: _messageLength,
+            labelOf: (m) => m.displayLabel,
+            onSelected: (m) {
+              VibrationService().vibrate(VibrationEffect.buttonTap);
+              setState(() => _messageLength = m);
+              widget.onSentenceLengthChanged?.call(m);
+            },
           ),
-          const SizedBox(height: 4),
-          Divider(
-            color: ColorCollection.point.withValues(alpha: 0.2),
-            thickness: 1,
-            height: 28,
-          ),
-          _SliderRow(
+          _divider(),
+          _StepperRow(
             label: '안내 문장 빠르기',
-            value: _ttsSpeed,
             description: '안내 메시지의 재생 속도를 조절합니다.',
-            // 0.5~5.0배속, 0.1 단위 스냅: (5.0 - 0.5) / 0.1 = 45 divisions
-            divisions: 45,
-            valueFormatter: (v) {
-              final speed = _ttsMin + v * (_ttsMax - _ttsMin);
-              return '${speed.toStringAsFixed(1)}배속';
-            },
-            onChanged: (v) {
-              setState(() => _ttsSpeed = v);
-              TtsService().setSpeechRate(_ttsSpeedValue);
-            },
-            onChangeEnd: (_) {
-              TtsService().speak(
-                '안내 음성 속도 조절 중입니다. 이 속도로 안내를 받게 됩니다.',
-                interrupt: true,
-              );
-              widget.onGuidanceSpeedChanged?.call(_ttsSpeedValue);
-            },
+            displayValue: '${_ttsSpeed.toStringAsFixed(1)}배속',
+            canDecrease: _ttsSpeed > _ttsMin,
+            canIncrease: _ttsSpeed < _ttsMax,
+            onDecrease: _decreaseSpeed,
+            onIncrease: _increaseSpeed,
           ),
-          const SizedBox(height: 4),
-          Divider(
-            color: ColorCollection.point.withValues(alpha: 0.2),
-            thickness: 1,
-            height: 28,
-          ),
-          _SliderRow(
+          _divider(),
+          _StepperRow(
             label: '진동 강도',
-            value: _vibrationStrength,
             description: '경고 진동의 강도를 조절합니다.',
-            divisions: 10,
-            onChanged: (v) {
-              setState(() => _vibrationStrength = v);
-              VibrationService().setStrength((v * _vibrationMax).round());
-            },
-            onChangeEnd: (v) =>
-                widget.onVibrationChanged?.call((v * _vibrationMax).round()),
+            displayValue: '$_vibration%',
+            canDecrease: _vibration > 0,
+            canIncrease: _vibration < _vibMax,
+            onDecrease: _decreaseVibration,
+            onIncrease: _increaseVibration,
           ),
         ],
       ),
     );
   }
+
+  Widget _divider() => Divider(
+    color: ColorCollection.point.withValues(alpha: 0.2),
+    thickness: 1,
+    height: 28,
+  );
+
+  void _decreaseSpeed() {
+    final next = (_ttsSpeed - _ttsStep).clamp(_ttsMin, _ttsMax);
+    setState(() => _ttsSpeed = next);
+    TtsService().setSpeechRate(next);
+    TtsService().speak('${next.toStringAsFixed(1)}배속', interrupt: true);
+    widget.onGuidanceSpeedChanged?.call(next);
+  }
+
+  void _increaseSpeed() {
+    final next = (_ttsSpeed + _ttsStep).clamp(_ttsMin, _ttsMax);
+    setState(() => _ttsSpeed = next);
+    TtsService().setSpeechRate(next);
+    TtsService().speak('${next.toStringAsFixed(1)}배속', interrupt: true);
+    widget.onGuidanceSpeedChanged?.call(next);
+  }
+
+  void _decreaseVibration() {
+    final next = (_vibration - _vibStep).clamp(0, _vibMax);
+    setState(() => _vibration = next);
+    VibrationService().setStrength(next);
+    VibrationService().vibrate(VibrationEffect.buttonTap);
+    widget.onVibrationChanged?.call(next);
+  }
+
+  void _increaseVibration() {
+    final next = (_vibration + _vibStep).clamp(0, _vibMax);
+    setState(() => _vibration = next);
+    VibrationService().setStrength(next);
+    VibrationService().vibrate(VibrationEffect.buttonTap);
+    widget.onVibrationChanged?.call(next);
+  }
 }
 
-class _SliderRow extends StatefulWidget {
+// ─── 세그먼트 선택 버튼 (안내 문장 길이) ──────────────────────────────────────────
+
+class _SegmentedRow<T> extends StatelessWidget {
   final String label;
-  final double value;
   final String description;
-  final ValueChanged<double> onChanged;
-  final ValueChanged<double>? onChangeEnd;
-  final String Function(double)? valueFormatter;
-  final int? divisions;
-  final List<String>? tickLabels;
+  final List<T> options;
+  final T selected;
+  final String Function(T) labelOf;
+  final void Function(T) onSelected;
 
-  const _SliderRow({
+  const _SegmentedRow({
     required this.label,
-    required this.value,
     required this.description,
-    required this.onChanged,
-    this.onChangeEnd,
-    this.valueFormatter,
-    this.divisions,
-    this.tickLabels,
+    required this.options,
+    required this.selected,
+    required this.labelOf,
+    required this.onSelected,
   });
-
-  @override
-  State<_SliderRow> createState() => _SliderRowState();
-}
-
-class _SliderRowState extends State<_SliderRow> {
-  late int _lastStep;
-
-  @override
-  void initState() {
-    super.initState();
-    _lastStep = _toStep(widget.value);
-  }
-
-  int _toStep(double v) =>
-      widget.divisions != null ? (v * widget.divisions!).round() : -1;
-
-  String get _displayValue => widget.valueFormatter != null
-      ? widget.valueFormatter!(widget.value)
-      : '${(widget.value * 100).round()}%';
-
-  void _handleChanged(double v) {
-    if (widget.divisions != null) {
-      final step = _toStep(v);
-      if (step != _lastStep) {
-        _lastStep = step;
-        VibrationService().vibrate(VibrationEffect.buttonTap);
-      }
-    }
-    widget.onChanged(v);
-  }
 
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // 레이블·현재값은 시각 전용 — 슬라이더가 포커스될 때 읽어줌
         ExcludeSemantics(
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                widget.label,
-                style: AppTextStyles.labelBold.copyWith(
-                  color: ColorCollection.point,
-                  fontWeight: FontWeight.w800,
-                ),
-              ),
-              Text(
-                _displayValue,
-                style: AppTextStyles.labelBold.copyWith(
-                  color: ColorCollection.main,
-                ),
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 14),
-        // MergeSemantics: 슬라이더의 value/action + label/설명을 하나의 노드로 병합
-        MergeSemantics(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Semantics(
-                label: '${widget.label}. ${widget.description}',
-              ),
-              SliderTheme(
-                data: SliderTheme.of(context).copyWith(
-                  trackHeight: 13,
-                  trackShape: _GradientTrackShape(),
-                  thumbShape: const _RoundedRectThumbShape(),
-                  overlayShape: SliderComponentShape.noOverlay,
-                  inactiveTrackColor:
-                      ColorCollection.point.withValues(alpha: 0.15),
-                  tickMarkShape: widget.tickLabels != null
-                      ? null
-                      : SliderTickMarkShape.noTickMark,
-                ),
-                child: Slider(
-                  value: widget.value,
-                  onChanged: _handleChanged,
-                  onChangeEnd: widget.onChangeEnd,
-                  divisions: widget.divisions,
-                  semanticFormatterCallback: (v) =>
-                      widget.valueFormatter != null
-                          ? widget.valueFormatter!(v)
-                          : '${(v * 100).round()}%',
-                ),
-              ),
-            ],
-          ),
-        ),
-        if (widget.tickLabels != null) ...[
-          const SizedBox(height: 5),
-          ExcludeSemantics(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: widget.tickLabels!
-                    .map(
-                      (t) => Text(
-                        t,
-                        style: AppTextStyles.labelRegular.copyWith(
-                          color: ColorCollection.point,
-                          fontWeight: FontWeight.w600,
-                          fontSize: 16,
-                        ),
-                      ),
-                    )
-                    .toList(),
-              ),
+          child: Text(
+            label,
+            style: AppTextStyles.labelBold.copyWith(
+              color: ColorCollection.point,
+              fontWeight: FontWeight.w800,
             ),
           ),
-          const SizedBox(height: 8),
-        ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: options.map((option) {
+            final isSelected = option == selected;
+            final optLabel = labelOf(option);
+            return Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                child: Semantics(
+                  label: '$label: $optLabel',
+                  selected: isSelected,
+                  button: true,
+                  excludeSemantics: true,
+                  child: GestureDetector(
+                    onTap: () => onSelected(option),
+                    child: Container(
+                      height: 52,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: isSelected
+                            ? ColorCollection.main
+                            : ColorCollection.point.withValues(alpha: 0.08),
+                        borderRadius: BorderRadius.circular(10),
+                        border: Border.all(
+                          color: isSelected
+                              ? ColorCollection.main
+                              : ColorCollection.point.withValues(alpha: 0.3),
+                          width: 2,
+                        ),
+                      ),
+                      child: Text(
+                        optLabel,
+                        style: AppTextStyles.labelBold.copyWith(
+                          color: isSelected ? Colors.white : ColorCollection.point,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }).toList(),
+        ),
         const SizedBox(height: 8),
         ExcludeSemantics(
           child: Text(
-            widget.description,
+            description,
             style: AppTextStyles.labelRegular.copyWith(
               color: ColorCollection.point,
               fontWeight: FontWeight.w400,
@@ -282,114 +237,146 @@ class _SliderRowState extends State<_SliderRow> {
   }
 }
 
-// ─── 그라데이션 트랙 ──────────────────────────────────────────────────────────
+// ─── + / − 스테퍼 (빠르기·진동 강도) ─────────────────────────────────────────────
 
-class _GradientTrackShape extends SliderTrackShape {
-  static const _gradient = LinearGradient(
-    colors: [Color(0xFFFFB06B), Color(0xFFE67E22)],
-    stops: [0.0, 0.4],
-  );
+class _StepperRow extends StatelessWidget {
+  final String label;
+  final String description;
+  final String displayValue;
+  final bool canDecrease;
+  final bool canIncrease;
+  final VoidCallback onDecrease;
+  final VoidCallback onIncrease;
 
-  @override
-  Rect getPreferredRect({
-    required RenderBox parentBox,
-    Offset offset = Offset.zero,
-    required SliderThemeData sliderTheme,
-    bool isEnabled = false,
-    bool isDiscrete = false,
-  }) {
-    final trackHeight = sliderTheme.trackHeight ?? 14;
-    final trackTop = offset.dy + (parentBox.size.height - trackHeight) / 2;
-    return Rect.fromLTWH(
-      offset.dx,
-      trackTop,
-      parentBox.size.width,
-      trackHeight,
-    );
-  }
+  const _StepperRow({
+    required this.label,
+    required this.description,
+    required this.displayValue,
+    required this.canDecrease,
+    required this.canIncrease,
+    required this.onDecrease,
+    required this.onIncrease,
+  });
 
   @override
-  void paint(
-    PaintingContext context,
-    Offset offset, {
-    required RenderBox parentBox,
-    required SliderThemeData sliderTheme,
-    required Animation<double> enableAnimation,
-    required Offset thumbCenter,
-    Offset? secondaryOffset,
-    bool isEnabled = false,
-    bool isDiscrete = false,
-    required TextDirection textDirection,
-  }) {
-    final canvas = context.canvas;
-    final rect = getPreferredRect(
-      parentBox: parentBox,
-      offset: offset,
-      sliderTheme: sliderTheme,
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ExcludeSemantics(
+          child: Text(
+            label,
+            style: AppTextStyles.labelBold.copyWith(
+              color: ColorCollection.point,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            _StepButton(
+              icon: Icons.remove,
+              semanticsLabel: '$label 줄이기',
+              enabled: canDecrease,
+              onTap: onDecrease,
+            ),
+            Expanded(
+              child: Semantics(
+                label: '$label: $displayValue',
+                child: Container(
+                  height: 52,
+                  alignment: Alignment.center,
+                  margin: const EdgeInsets.symmetric(horizontal: 8),
+                  decoration: BoxDecoration(
+                    color: ColorCollection.point.withValues(alpha: 0.08),
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(color: ColorCollection.main, width: 2),
+                  ),
+                  child: ExcludeSemantics(
+                    child: Text(
+                      displayValue,
+                      style: AppTextStyles.labelBold.copyWith(
+                        color: ColorCollection.main,
+                        fontWeight: FontWeight.w800,
+                        fontSize: 20,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            _StepButton(
+              icon: Icons.add,
+              semanticsLabel: '$label 늘리기',
+              enabled: canIncrease,
+              onTap: onIncrease,
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ExcludeSemantics(
+          child: Text(
+            description,
+            style: AppTextStyles.labelRegular.copyWith(
+              color: ColorCollection.point,
+              fontWeight: FontWeight.w400,
+              fontSize: 16,
+            ),
+          ),
+        ),
+      ],
     );
-    final radius = Radius.circular(rect.height / 2);
-
-    // 비활성 트랙 (전체 배경)
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(rect, radius),
-      Paint()
-        ..color =
-            sliderTheme.inactiveTrackColor ??
-            ColorCollection.point.withValues(alpha: 0.15),
-    );
-
-    // 활성 트랙 (그라데이션)
-    final activeRect = Rect.fromLTRB(
-      rect.left,
-      rect.top,
-      thumbCenter.dx,
-      rect.bottom,
-    );
-    if (activeRect.width > 0) {
-      canvas.drawRRect(
-        RRect.fromRectAndRadius(activeRect, radius),
-        Paint()..shader = _gradient.createShader(activeRect),
-      );
-    }
   }
 }
 
-// ─── 가로형 Thumb ─────────────────────────────────────────────────────────────
+class _StepButton extends StatelessWidget {
+  final IconData icon;
+  final String semanticsLabel;
+  final bool enabled;
+  final VoidCallback onTap;
 
-class _RoundedRectThumbShape extends SliderComponentShape {
-  const _RoundedRectThumbShape();
-
-  static const double _width = 20;
-  static const double _height = 13;
+  const _StepButton({
+    required this.icon,
+    required this.semanticsLabel,
+    required this.enabled,
+    required this.onTap,
+  });
 
   @override
-  Size getPreferredSize(bool isEnabled, bool isDiscrete) =>
-      const Size(_width, _height);
-
-  @override
-  void paint(
-    PaintingContext context,
-    Offset center, {
-    required Animation<double> activationAnimation,
-    required Animation<double> enableAnimation,
-    required bool isDiscrete,
-    required TextPainter labelPainter,
-    required RenderBox parentBox,
-    required SliderThemeData sliderTheme,
-    required TextDirection textDirection,
-    required double value,
-    required double textScaleFactor,
-    required Size sizeWithOverflow,
-  }) {
-    final canvas = context.canvas;
-    final rect = Rect.fromCenter(
-      center: center,
-      width: _width,
-      height: _height,
-    );
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(rect, const Radius.circular(6)),
-      Paint()..color = ColorCollection.point,
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticsLabel,
+      button: true,
+      enabled: enabled,
+      excludeSemantics: true,
+      child: GestureDetector(
+        onTap: enabled ? onTap : null,
+        child: Container(
+          width: 56,
+          height: 52,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: enabled
+                ? ColorCollection.main.withValues(alpha: 0.15)
+                : ColorCollection.point.withValues(alpha: 0.05),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: enabled
+                  ? ColorCollection.main
+                  : ColorCollection.point.withValues(alpha: 0.2),
+              width: 2,
+            ),
+          ),
+          child: Icon(
+            icon,
+            color: enabled
+                ? ColorCollection.main
+                : ColorCollection.point.withValues(alpha: 0.3),
+            size: 28,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
@@ -8,10 +9,7 @@ import 'package:safepath/service/vibration_service.dart';
 
 /// 안내 스타일 개인화 섹션 (접근성 개선 버전)
 ///
-/// 슬라이더 대신 탭 한 번으로 조작 가능한 버튼 UI 사용:
-///  - 안내 문장 길이 → 3개 세그먼트 버튼 (간결 / 보통 / 상세)
-///  - 안내 문장 빠르기 → − / + 스테퍼 (0.5배속 단위)
-///  - 진동 강도 → − / + 스테퍼 (10% 단위)
+/// 읽기 순서: 제목(header) → 현재 설정값 → 조작 버튼 → 설명(시각 전용)
 class SettingsStyleWidget extends StatefulWidget {
   final UserSettings initialSettings;
   final void Function(MessageLength)? onSentenceLengthChanged;
@@ -83,6 +81,7 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
           _divider(),
           _StepperRow(
             label: '안내 문장 빠르기',
+            buttonLabel: '빠르기',
             description: '안내 메시지의 재생 속도를 조절합니다.',
             displayValue: '${_ttsSpeed.toStringAsFixed(1)}배속',
             canDecrease: _ttsSpeed > _ttsMin,
@@ -93,6 +92,7 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
           _divider(),
           _StepperRow(
             label: '진동 강도',
+            buttonLabel: '강도',
             description: '경고 진동의 강도를 조절합니다.',
             displayValue: '$_vibration%',
             canDecrease: _vibration > 0,
@@ -118,10 +118,7 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
     final next = (_ttsSpeed - _ttsStep).clamp(_ttsMin, _ttsMax);
     setState(() => _ttsSpeed = next);
     TtsService().setSpeechRate(next);
-    TtsService().speak(
-      '${_speedLabel(next)}. 안내 음성 속도 조절 중입니다. 이 속도로 안내를 받게 됩니다.',
-      interrupt: true,
-    );
+    TtsService().speak('${_speedLabel(next)}으로 변경됐습니다.', interrupt: true);
     widget.onGuidanceSpeedChanged?.call(next);
   }
 
@@ -129,10 +126,7 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
     final next = (_ttsSpeed + _ttsStep).clamp(_ttsMin, _ttsMax);
     setState(() => _ttsSpeed = next);
     TtsService().setSpeechRate(next);
-    TtsService().speak(
-      '${_speedLabel(next)}. 안내 음성 속도 조절 중입니다. 이 속도로 안내를 받게 됩니다.',
-      interrupt: true,
-    );
+    TtsService().speak('${_speedLabel(next)}으로 변경됐습니다.', interrupt: true);
     widget.onGuidanceSpeedChanged?.call(next);
   }
 
@@ -154,6 +148,8 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
 }
 
 // ─── 세그먼트 선택 버튼 (안내 문장 길이) ──────────────────────────────────────────
+//
+// 읽기 순서: "제목" → "현재 설정: 간결" → "간결, 선택됨, 버튼" … → (설명, 시각 전용)
 
 class _SegmentedRow<T> extends StatelessWidget {
   final String label;
@@ -174,10 +170,15 @@ class _SegmentedRow<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final currentLabel = labelOf(selected);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        ExcludeSemantics(
+        // 1. 제목 + 현재값 (시각: 레이블만, TalkBack: "제목, 현재 값")
+        Semantics(
+          header: true,
+          label: '$label, 현재 $currentLabel',
+          excludeSemantics: true,
           child: Text(
             label,
             style: AppTextStyles.labelBold.copyWith(
@@ -187,6 +188,7 @@ class _SegmentedRow<T> extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 12),
+        // 3. 선택 버튼
         Row(
           children: options.map((option) {
             final isSelected = option == selected;
@@ -195,12 +197,18 @@ class _SegmentedRow<T> extends StatelessWidget {
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4),
                 child: Semantics(
-                  label: '$label: $optLabel',
+                  label: optLabel,
                   selected: isSelected,
                   button: true,
                   excludeSemantics: true,
                   child: GestureDetector(
-                    onTap: () => onSelected(option),
+                    onTap: () {
+                      onSelected(option);
+                      SemanticsService.announce(
+                        '$optLabel 선택됨',
+                        TextDirection.ltr,
+                      );
+                    },
                     child: Container(
                       height: 52,
                       alignment: Alignment.center,
@@ -231,6 +239,7 @@ class _SegmentedRow<T> extends StatelessWidget {
           }).toList(),
         ),
         const SizedBox(height: 8),
+        // 4. 설명 (시각 전용 — 제목만으로 충분히 유추 가능)
         ExcludeSemantics(
           child: Text(
             description,
@@ -247,9 +256,13 @@ class _SegmentedRow<T> extends StatelessWidget {
 }
 
 // ─── + / − 스테퍼 (빠르기·진동 강도) ─────────────────────────────────────────────
+//
+// 읽기 순서: "제목" → "현재 설정: N" → "줄이기 버튼" → "현재값" → "늘리기 버튼"
+//           → (설명, 시각 전용)
 
 class _StepperRow extends StatelessWidget {
   final String label;
+  final String buttonLabel; // 버튼 레이블 단축형 (e.g. "빠르기", "강도")
   final String description;
   final String displayValue;
   final bool canDecrease;
@@ -259,6 +272,7 @@ class _StepperRow extends StatelessWidget {
 
   const _StepperRow({
     required this.label,
+    required this.buttonLabel,
     required this.description,
     required this.displayValue,
     required this.canDecrease,
@@ -272,7 +286,11 @@ class _StepperRow extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        ExcludeSemantics(
+        // 1. 제목 + 현재값 (시각: 레이블만, TalkBack: "제목, 현재 값")
+        Semantics(
+          header: true,
+          label: '$label, 현재 $displayValue',
+          excludeSemantics: true,
           child: Text(
             label,
             style: AppTextStyles.labelBold.copyWith(
@@ -282,17 +300,18 @@ class _StepperRow extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 12),
+        // 3. 스테퍼 (− 값 +)
         Row(
           children: [
             _StepButton(
               icon: Icons.remove,
-              semanticsLabel: '$label 줄이기',
+              semanticsLabel: '$buttonLabel 감소',
               enabled: canDecrease,
               onTap: onDecrease,
             ),
             Expanded(
               child: Semantics(
-                label: '$label: $displayValue',
+                label: displayValue,
                 child: Container(
                   height: 52,
                   alignment: Alignment.center,
@@ -317,13 +336,14 @@ class _StepperRow extends StatelessWidget {
             ),
             _StepButton(
               icon: Icons.add,
-              semanticsLabel: '$label 늘리기',
+              semanticsLabel: '$buttonLabel 증가',
               enabled: canIncrease,
               onTap: onIncrease,
             ),
           ],
         ),
         const SizedBox(height: 8),
+        // 4. 설명 (시각 전용)
         ExcludeSemantics(
           child: Text(
             description,

--- a/frontend/lib/features/settings/settings_style_widget.dart
+++ b/frontend/lib/features/settings/settings_style_widget.dart
@@ -111,11 +111,17 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
     height: 28,
   );
 
+  String _speedLabel(double speed) =>
+      '${speed.toStringAsFixed(1).replaceAll('.', '점')}배속';
+
   void _decreaseSpeed() {
     final next = (_ttsSpeed - _ttsStep).clamp(_ttsMin, _ttsMax);
     setState(() => _ttsSpeed = next);
     TtsService().setSpeechRate(next);
-    TtsService().speak('${next.toStringAsFixed(1)}배속', interrupt: true);
+    TtsService().speak(
+      '${_speedLabel(next)}. 안내 음성 속도 조절 중입니다. 이 속도로 안내를 받게 됩니다.',
+      interrupt: true,
+    );
     widget.onGuidanceSpeedChanged?.call(next);
   }
 
@@ -123,7 +129,10 @@ class _SettingsStyleWidgetState extends State<SettingsStyleWidget> {
     final next = (_ttsSpeed + _ttsStep).clamp(_ttsMin, _ttsMax);
     setState(() => _ttsSpeed = next);
     TtsService().setSpeechRate(next);
-    TtsService().speak('${next.toStringAsFixed(1)}배속', interrupt: true);
+    TtsService().speak(
+      '${_speedLabel(next)}. 안내 음성 속도 조절 중입니다. 이 속도로 안내를 받게 됩니다.',
+      interrupt: true,
+    );
     widget.onGuidanceSpeedChanged?.call(next);
   }
 

--- a/frontend/lib/service/tts_service.dart
+++ b/frontend/lib/service/tts_service.dart
@@ -46,6 +46,19 @@ class TtsService {
     _tts.setCancelHandler(() {
       _isSpeaking = false;
       debugPrint('🔊 [TTS] 음성 출력 취소');
+      // 외부 인터럽트(TalkBack 스크롤 피드백 등)로 취소된 경우
+      // 대기 중인 nav 안내가 있으면 짧은 지연 후 재시도
+      final pending = _pendingNavMessage;
+      if (pending != null) {
+        _pendingNavMessage = null;
+        Future.delayed(const Duration(milliseconds: 600), () {
+          if (!_isSpeaking && _voiceGuidanceEnabled) {
+            debugPrint('🔊 [TTS] 취소 후 대기 nav 안내 재시도: $pending');
+            _isSpeaking = true;
+            _tts.speak(pending);
+          }
+        });
+      }
     });
 
     _tts.setErrorHandler((msg) {


### PR DESCRIPTION
## 📎 Issue 번호
<!-- close #번호 형식으로 작성 (예: close #42) -->
#75 #84 

## 📄 작업 내용 요약
### 접근성 개선
- 설정 항목 전체를 포커스 가능 영역으로 확장하여 터치 탐색 개선
- TalkBack 읽기 순서 및 semantics 구조 수정
- 스위치 상태(on/off) 중복 읽기 제거
- 설정 제목에 현재 설정값을 함께 읽도록 개선
- 세그먼트 및 스테퍼 UI의 접근성 피드백 개선
- 중앙 값 영역(40%, 5.0배속)을 read-only semantics로 노출하여 dead zone 제거
- 설정 변경 시 announce를 통한 상태 변경 피드백 추가
### TTS 개선
- TalkBack 스크롤 등 외부 interrupt로 인해 TTS 안내가 유실되는 문제 수정
- cancelHandler에서 pending navigation message 재시도 로직 추가
- 앱 내부 stop() 호출과 외부 interrupt를 구분하도록 개선
- TalkBack 음성과 앱 TTS 간 충돌 상황 대응 로직 추가
### UI/UX 개선
- 설정 설명 및 현재 상태 표시 구조 개선
- 스크린리더 사용 시 탐색 흐름 최적화
- 설정값 조절 인터랙션 개선

## 📸 스크린샷 (UI 변경 시 작성, 없으면 삭제)
<img width="1080" height="4169" alt="KakaoTalk_20260509_022438562" src="https://github.com/user-attachments/assets/0cdf84da-0f85-4e19-aa6d-4d77cd1e304d" />

## ✅ 체크리스트

- [x] 빌드 및 실행이 정상 동작한다
- [x] Breaking change 없음 (있다면 작업 내용 요약에 명시)
- [x] 테스트를 했거나, 기존 테스트로 충분하다
- [x] 커밋 메시지가 작업 내용과 일치한다
- [x] 셀프 리뷰를 완료했다