### PR TITLE
[FIX] 길안내 pass-through zone 거리 표시 및 TTS 반복 안내 버그 수정

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -222,7 +222,6 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
       step.longitude!,
     );
 
-    setState(() => _debugDistance = distance);
     final direction = _turnTypeToDirection(step.turnType);
 
     if (!_showStartOverview &&
@@ -245,6 +244,19 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         if (mounted) setState(() => _showStartOverview = false);
       });
     }
+
+    // minDist를 먼저 업데이트해야 inPassThroughZone 판단이 정확함
+    if (distance < _minDistanceToStep) _minDistanceToStep = distance;
+
+    // 10m 이내 진입 이후 → pass-through zone
+    // 이 구간에서는 거리가 다시 증가해도 UI/TTS에 반영하지 않음
+    final inPassThroughZone =
+        _hasBeenOutsideThreshold && _minDistanceToStep < _arrivalThresholdMeters;
+
+    if (!inPassThroughZone) {
+      setState(() => _debugDistance = distance);
+    }
+
     debugPrint(
       '📍 [Nav] step $_currentStepIndex/${_pointSteps.length - 1} | '
       '거리: ${distance.toStringAsFixed(1)}m | '
@@ -253,12 +265,9 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
       '${_hasBeenOutsideThreshold ? "진행 중" : "대기 중"}',
     );
 
-    if (distance < _minDistanceToStep) _minDistanceToStep = distance;
-
     // pass-through 완수: 10m 이내 진입 후 최근접 지점에서 8m 이상 멀어지면 완수
     // (distance >= 10m 분기보다 먼저 체크해야 함 — minDist + 8m >= 10m 인 경우를 커버)
-    if (_hasBeenOutsideThreshold &&
-        _minDistanceToStep < _arrivalThresholdMeters &&
+    if (inPassThroughZone &&
         distance > _minDistanceToStep + _passThroughOffsetMeters) {
       setState(() {
         _currentStepIndex++;
@@ -273,10 +282,12 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
 
     if (distance >= _arrivalThresholdMeters) {
       _hasBeenOutsideThreshold = true;
-      NavigationTtsService().speakDistance(direction, distance.round(), step.description ?? '');
+      // pass-through zone에서 거리가 다시 10m 이상으로 튀어도 TTS 차단
+      if (!inPassThroughZone) {
+        NavigationTtsService().speakDistance(direction, distance.round(), step.description ?? '');
+      }
     } else if (_hasBeenOutsideThreshold) {
-      // pass-through zone — 아직 완수 조건 미충족, TTS 안내 유지
-      NavigationTtsService().speakDistance(direction, distance.round(), step.description ?? '');
+      // pass-through zone — 거리 증가 안내 방지를 위해 speakDistance 호출하지 않음
     } else {
       // 처음부터 10m 이내 → 이미 지난 step으로 간주하고 skip (TTS 없음)
       setState(() {


### PR DESCRIPTION
## 📎 Issue 번호
#96 

## 📄 작업 내용 요약
- step 통과 감지(pass-through) 구간에서 거리가 다시 증가할 때 UI 카드와 보이스가이드에 반영되던 문제 수정                                                                                                 
- pass-through zone 내 speakDistance 중복 호출 차단

## ✅ 체크리스트
- [ ] step 지점 통과 후 카드 거리 표시가 고정(freeze)되고 증가하지 않는지 확인                                                                                                                            
- [ ] pass-through zone에서 "잠시 후 A하기" 보이스가이드가 반복 발화되지 않는지 확인
- [ ] step 완수 후 다음 step 안내가 정상적으로 발화되는지 확인                                                                                                                                            
- [ ] GPS가 pass-through zone 중 10m 바깥으로 튀어도 TTS가 발화되지 않는지 확인
