### PR TITLE
[FEAT] 횡단보도 음성신호기 API 연동 및 길찾기 TTS 안내 추가

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -15,6 +15,7 @@ import 'package:safepath/features/navigation/navigation_voiceguide_card.dart';
 import 'package:safepath/model/detection_event.dart';
 import 'package:safepath/service/camera_service.dart';
 import 'package:safepath/service/detection_ws_service.dart';
+import 'package:safepath/service/crosswalk_service.dart';
 import 'package:safepath/service/navigation_service.dart';
 import 'package:safepath/service/navigation_tts_service.dart';
 import 'package:safepath/service/sound_effect_service.dart';
@@ -60,6 +61,10 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   static const int _deviationCountThreshold = 3;
   int _deviationCount = 0;
   bool _isRecalculating = false;
+
+  // 횡단보도 음성신호기 캐시 (step index → CrosswalkInfo?)
+  Map<int, CrosswalkInfo?> _crosswalkCache = {};
+  int _prefetchGeneration = 0;
 
   // 장애물 탐지 (카메라 + WS)
   StreamSubscription<DetectionEvent>? _wsSub;
@@ -189,6 +194,29 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     debugPrint(
       '  [목적지] (${_destinationStep?.latitude}, ${_destinationStep?.longitude})',
     );
+
+    _prefetchCrosswalks();
+  }
+
+  Future<void> _prefetchCrosswalks() async {
+    final myGeneration = ++_prefetchGeneration;
+    for (int i = 0; i < _pointSteps.length; i++) {
+      if (!mounted || _prefetchGeneration != myGeneration) return;
+      final step = _pointSteps[i];
+      if (step.facilityType == 15 &&
+          step.latitude != null &&
+          step.longitude != null) {
+        final info = await CrosswalkService.getNearby(
+          lat: step.latitude!,
+          lng: step.longitude!,
+        );
+        if (!mounted || _prefetchGeneration != myGeneration) return;
+        _crosswalkCache[i] = info;
+        debugPrint(
+          '🚦 [Crosswalk] step[$i] → acousticSignal=${info?.acousticSignalInstalled}, summary=${info?.guidanceSummary}',
+        );
+      }
+    }
   }
 
   void _startLocationTracking() {
@@ -327,9 +355,15 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   void _speakNextStepOrDestination() {
     if (_currentStepIndex < _pointSteps.length) {
       final next = _pointSteps[_currentStepIndex];
+      final crosswalk = _crosswalkCache[_currentStepIndex];
+      final acousticSuffix =
+          (crosswalk?.acousticSignalInstalled == true &&
+                  crosswalk!.guidanceSummary.isNotEmpty)
+              ? ' ${crosswalk.guidanceSummary}'
+              : '';
       NavigationTtsService().speakStep(
         _turnTypeToDirection(next.turnType),
-        next.description ?? '',
+        '${next.description ?? ''}$acousticSuffix'.trim(),
       );
     } else {
       // 모든 step 완료 → 목적지 직진 안내
@@ -399,6 +433,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         _debugDistance = null;
         _hasArrived = false;
         _isRecalculating = false;
+        _crosswalkCache = {};
       });
       _loadRoute(result);
       // 재탐색 후 overview 카드 없이 새 경로 첫 step 바로 안내

--- a/frontend/lib/models/route_result.dart
+++ b/frontend/lib/models/route_result.dart
@@ -30,6 +30,7 @@ class RouteStep {
   final String? description;
   final int? turnType;
   final String? pointType; // "SP"=출발, "EP"=도착
+  final int? facilityType; // 15 = 횡단보도
 
   // LINE 전용
   final List<LatLng>? path;
@@ -41,6 +42,7 @@ class RouteStep {
     this.description,
     this.turnType,
     this.pointType,
+    this.facilityType,
     this.path,
   });
 
@@ -62,6 +64,7 @@ class RouteStep {
       description: json['description'] as String?,
       turnType: json['turnType'] as int?,
       pointType: json['pointType'] as String?,
+      facilityType: json['facilityType'] as int?,
     );
   }
 }

--- a/frontend/lib/models/route_result.dart
+++ b/frontend/lib/models/route_result.dart
@@ -64,7 +64,7 @@ class RouteStep {
       description: json['description'] as String?,
       turnType: json['turnType'] as int?,
       pointType: json['pointType'] as String?,
-      facilityType: json['facilityType'] as int?,
+      facilityType: int.tryParse(json['facilityType']?.toString() ?? ''),
     );
   }
 }

--- a/frontend/lib/service/crosswalk_service.dart
+++ b/frontend/lib/service/crosswalk_service.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+import 'package:flutter/cupertino.dart';
+import 'package:http/http.dart' as http;
+
+class CrosswalkInfo {
+  final bool acousticSignalInstalled;
+  final String guidanceSummary;
+
+  const CrosswalkInfo({
+    required this.acousticSignalInstalled,
+    required this.guidanceSummary,
+  });
+}
+
+class CrosswalkService {
+  static const String _baseUrl = String.fromEnvironment('BASE_URL');
+
+  /// 횡단보도 음성신호기 정보 조회
+  /// 거리순 정렬 결과 중 0번째 항목만 사용
+  static Future<CrosswalkInfo?> getNearby({
+    required double lat,
+    required double lng,
+    double radiusMeters = 50,
+  }) async {
+    try {
+      final uri = Uri.parse('$_baseUrl/api/crosswalks/nearby').replace(
+        queryParameters: {
+          'latitude': lat.toString(),
+          'longitude': lng.toString(),
+          'radiusMeters': radiusMeters.toString(),
+        },
+      );
+      debugPrint('🟡 [Crosswalk] 요청: GET $uri');
+
+      final response = await http.get(uri);
+
+      debugPrint('📥 statusCode: ${response.statusCode}');
+      debugPrint('📥 body: ${response.body}');
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        if (data['success'] == true) {
+          final list = data['data'] as List?;
+          if (list == null || list.isEmpty) return null;
+
+          final item = list[0] as Map<String, dynamic>;
+          final acousticSignal = item['acousticSignal'] as Map<String, dynamic>?;
+          final guidance = item['guidance'] as Map<String, dynamic>?;
+
+          return CrosswalkInfo(
+            acousticSignalInstalled: acousticSignal?['installed'] as bool? ?? false,
+            guidanceSummary: guidance?['summary'] as String? ?? '',
+          );
+        }
+      }
+
+      return null;
+    } catch (e) {
+      debugPrint('🔴 [Crosswalk] getNearby error: $e');
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## 📎 Issue 번호
#99 

## 📄 작업 내용 요약
- 횡단보도 음성신호기 정보 연동                                                                                                                                                                       
  - `RouteStep`에 `facilityType` 필드 추가 (`15` = 횡단보도 스텝)
  - `CrosswalkService` 신규 추가: `GET /api/crosswalks/nearby` 호출하여 반경 50m 내 횡단보도 음성신호기 설치 여부 및 안내문 조회
  - `CrosswalkInfo` 모델: `acousticSignalInstalled`, `guidanceSummary` 필드                                                                                                                                 
                                              
- 길찾기 화면 TTS 연동                                                                                                                                                                                  
  - 경로 로드 시 `facilityType == 15`인 스텝을 순회하며 API 사전 호출 후 결과를 `_crosswalkCache`에 캐싱                                                                                                    
  - 스텝 전환 안내 시 해당 스텝에 음성신호기가 설치된 경우, 스텝 메시지에 `guidanceSummary`를 이어붙여 한 번에 TTS 재생                                                                                     
  - 경로 재탐색 시 캐시 초기화 후 새 경로 기준으로 재프리패치                                                                                                                                               
                                                                                                                                                                                                            
- 안정성 처리                                                                                                                                                                                           
  - 세대 카운터(`_prefetchGeneration`) 도입: 재탐색 중 이전 경로의 API 응답이 늦게 도착해도 캐시 오염 방지                                                                                                  
  - `mounted` 체크: 위젯 dispose 후 캐시 쓰기 방지

## ✅ 체크리스트
- [x] `/api/crosswalks/nearby` 요청 파라미터(위도·경도·반경) 정상 전달 확인                                                                                                                             
- [x] 음성신호기 있는 횡단보도 응답 정상 파싱 확인                                                                                                                                                        
- [x] 반경 내 횡단보도 없을 때 null 반환 확인                                                                                                                                                             
- [x] 네트워크 오류 시 null 반환 (앱 크래시 없음) 확인                                                                                                                                                                                                           
- [x] 경로 로드 후 facilityType=15 스텝에 대해서만 API 호출되는지 로그 확인                                                                                                                               
- [x] 경로 재탐색 후 이전 캐시 초기화 및 새 경로 기준으로 재프리패치 확인                                                                                                                                                                                                                                                                                                                      
- [x] 음성신호기 있는 횡단보도 스텝 전환 시 스텝 메시지 + 안내문 이어서 재생 확인                                                                                                                         
- [x] 음성신호기 없는 횡단보도 스텝에서 기존 스텝 메시지만 재생 확인                                                                                                                                      
- [x] 일반 스텝에서 TTS 동작 변화 없음 확인                                                                                                                                                                                                                                                                                                                                                             
- [x] 길찾기 진입 직후 빠르게 뒤로 가기 시 크래시 없음 확인                                                                                                                                             
- [x] 횡단보도 스텝이 없는 경로에서 정상 동작 확인