### PR TITLE
[REFACTOR] 코드 리뷰 반영 - CrosswalkInfo 모델 분리 및 import 정리

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -15,6 +15,7 @@ import 'package:safepath/features/navigation/navigation_voiceguide_card.dart';
 import 'package:safepath/model/detection_event.dart';
 import 'package:safepath/service/camera_service.dart';
 import 'package:safepath/service/detection_ws_service.dart';
+import 'package:safepath/models/crosswalk_info.dart';
 import 'package:safepath/service/crosswalk_service.dart';
 import 'package:safepath/service/navigation_service.dart';
 import 'package:safepath/service/navigation_tts_service.dart';

--- a/frontend/lib/models/crosswalk_info.dart
+++ b/frontend/lib/models/crosswalk_info.dart
@@ -1,0 +1,9 @@
+class CrosswalkInfo {
+  final bool acousticSignalInstalled;
+  final String guidanceSummary;
+
+  const CrosswalkInfo({
+    required this.acousticSignalInstalled,
+    required this.guidanceSummary,
+  });
+}

--- a/frontend/lib/service/crosswalk_service.dart
+++ b/frontend/lib/service/crosswalk_service.dart
@@ -1,21 +1,12 @@
 import 'dart:convert';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-
-class CrosswalkInfo {
-  final bool acousticSignalInstalled;
-  final String guidanceSummary;
-
-  const CrosswalkInfo({
-    required this.acousticSignalInstalled,
-    required this.guidanceSummary,
-  });
-}
+import 'package:safepath/models/crosswalk_info.dart';
 
 class CrosswalkService {
   static const String _baseUrl = String.fromEnvironment('BASE_URL');
 
-  /// 횡단보도 음성신호기 정보 조회
+  /// 횡단보도 음성신호기 정보 조회 (공개 엔드포인트 — Authorization 헤더 불필요)
   /// 거리순 정렬 결과 중 0번째 항목만 사용
   static Future<CrosswalkInfo?> getNearby({
     required double lat,


### PR DESCRIPTION
## 📎 Issue 번호
#99 

## 📄 작업 내용 요약
 코드 리뷰 피드백 반영                                                                                                                                                                                                        
- `CrosswalkInfo` 클래스를 `lib/models/crosswalk_info.dart`로 분리
- `crosswalk_service.dart` import를 `flutter/cupertino.dart` → `flutter/foundation.dart` 로 교체                                                                                                          
- `/api/crosswalks/nearby` 가 공개 엔드포인트임을 주석으로 명시  

## ✅ 체크리스트
- [x] 빌드 및 실행이 정상 동작한다                                                                                                                                                                        
- [x] Breaking change 없음                                                                                                                                                                              
- [x] 커밋 메시지가 작업 내용과 일치한다
- [x] 셀프 리뷰를 완료했다
