### PR TITLE
[FEAT] 저장된 장소 화면 스크린리더 접근성(Semantics) 추가

### DIFF
--- a/frontend/lib/common/widgets/text_input_bar.dart
+++ b/frontend/lib/common/widgets/text_input_bar.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/service/sound_effect_service.dart';
@@ -49,6 +49,7 @@ class TextInputBar extends StatelessWidget {
                     return const SizedBox.shrink();
                   }
                   return IconButton(
+                    tooltip: '입력 지우기',
                     icon: const Icon(Icons.close, color: ColorCollection.main),
                     onPressed: () {
                       SoundEffectService().play(SoundEffect.buttonTap);
@@ -85,30 +86,37 @@ class TextInputBar extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 14),
-        Material(
-          color: Colors.transparent,
-          borderRadius: BorderRadius.circular(10),
-          child: InkWell(
+        Semantics(
+          button: true,
+          label: '음성 입력',
+          enabled: micTap != null,
+          onTap: micTap,
+          excludeSemantics: true,
+          child: Material(
+            color: Colors.transparent,
             borderRadius: BorderRadius.circular(10),
-            onTap: micTap == null
-                ? null
-                : () {
-                    SoundEffectService().play(SoundEffect.buttonTap);
-              VibrationService().vibrate(VibrationEffect.buttonTap);
-                    micTap!();
-                  },
-            child: Container(
-              width: 55,
-              height: 55,
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: ColorCollection.main,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: const Icon(
-                Icons.mic,
-                color: ColorCollection.point,
-                size: 40,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(10),
+              onTap: micTap == null
+                  ? null
+                  : () {
+                      SoundEffectService().play(SoundEffect.buttonTap);
+                      VibrationService().vibrate(VibrationEffect.buttonTap);
+                      micTap!();
+                    },
+              child: Container(
+                width: 55,
+                height: 55,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: ColorCollection.main,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: const Icon(
+                  Icons.mic,
+                  color: ColorCollection.point,
+                  size: 40,
+                ),
               ),
             ),
           ),

--- a/frontend/lib/features/navigation/add_place_screen.dart
+++ b/frontend/lib/features/navigation/add_place_screen.dart
@@ -318,9 +318,14 @@ class _AddPlaceScreenState extends State<AddPlaceScreen> {
                   left: 0,
                   right: 0,
                   child: isLoading
-                      ? const Padding(
-                          padding: EdgeInsets.all(16.0),
-                          child: Center(child: CircularProgressIndicator()),
+                      ? Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: Center(
+                            child: Semantics(
+                              label: '검색 중',
+                              child: const CircularProgressIndicator(),
+                            ),
+                          ),
                         )
                       : searchResults.isNotEmpty
                       ? ResultList(

--- a/frontend/lib/features/navigation/address_section.dart
+++ b/frontend/lib/features/navigation/address_section.dart
@@ -27,11 +27,14 @@ class AddressSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '장소 주소 선택',
-          style: AppTextStyles.title2.copyWith(
-            color: ColorCollection.point,
-            fontSize: 20,
+        Semantics(
+          header: true,
+          child: Text(
+            '장소 주소 선택',
+            style: AppTextStyles.title2.copyWith(
+              color: ColorCollection.point,
+              fontSize: 20,
+            ),
           ),
         ),
         const SizedBox(height: 15),

--- a/frontend/lib/features/navigation/category_item.dart
+++ b/frontend/lib/features/navigation/category_item.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:safepath/common/enum/place_category.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
@@ -19,50 +19,57 @@ class CategoryItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap == null
-          ? null
-          : () {
-              SoundEffectService().play(SoundEffect.buttonTap);
-              VibrationService().vibrate(VibrationEffect.buttonTap);
-              onTap!();
-            },
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(2, 5, 2, 5),
-        decoration: BoxDecoration(
-          color: Colors.transparent,
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(
-            color: isSelected ? ColorCollection.point : Colors.transparent,
-            width: 3,
+    return Semantics(
+      button: true,
+      label: category.label,
+      selected: isSelected,
+      hint: isSelected ? '선택됨' : null,
+      excludeSemantics: true,
+      child: GestureDetector(
+        onTap: onTap == null
+            ? null
+            : () {
+                SoundEffectService().play(SoundEffect.buttonTap);
+                VibrationService().vibrate(VibrationEffect.buttonTap);
+                onTap!();
+              },
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(2, 5, 2, 5),
+          decoration: BoxDecoration(
+            color: Colors.transparent,
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: isSelected ? ColorCollection.point : Colors.transparent,
+              width: 3,
+            ),
           ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Container(
-              width: 50,
-              height: 50,
-              decoration: BoxDecoration(
-                color: ColorCollection.main,
-                borderRadius: BorderRadius.circular(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Container(
+                width: 50,
+                height: 50,
+                decoration: BoxDecoration(
+                  color: ColorCollection.main,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Icon(
+                  category.icon,
+                  color: ColorCollection.point,
+                  size: 35,
+                ),
               ),
-              child: Icon(
-                category.icon,
-                color: ColorCollection.point,
-                size: 35,
+              const SizedBox(height: 10),
+              Text(
+                category.label,
+                textAlign: TextAlign.center,
+                style: AppTextStyles.labelBold.copyWith(
+                  color: ColorCollection.point,
+                  fontSize: 16,
+                ),
               ),
-            ),
-            const SizedBox(height: 10),
-            Text(
-              category.label,
-              textAlign: TextAlign.center,
-              style: AppTextStyles.labelBold.copyWith(
-                color: ColorCollection.point,
-                fontSize: 16,
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/frontend/lib/features/navigation/category_section.dart
+++ b/frontend/lib/features/navigation/category_section.dart
@@ -19,11 +19,14 @@ class CategorySection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '대표 아이콘 설정',
-          style: AppTextStyles.title2.copyWith(
-            color: ColorCollection.point,
-            fontSize: 20,
+        Semantics(
+          header: true,
+          child: Text(
+            '대표 아이콘 설정',
+            style: AppTextStyles.title2.copyWith(
+              color: ColorCollection.point,
+              fontSize: 20,
+            ),
           ),
         ),
         const SizedBox(height: 15),

--- a/frontend/lib/features/navigation/current_place_widget.dart
+++ b/frontend/lib/features/navigation/current_place_widget.dart
@@ -22,7 +22,10 @@ class CurrentPlaceWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return Semantics(
+      label: '$label, $location',
+      excludeSemantics: true,
+      child: Container(
       decoration: BoxDecoration(
         color: ColorCollection.point.withOpacity(0.1),
         borderRadius: BorderRadius.circular(10),
@@ -68,6 +71,7 @@ class CurrentPlaceWidget extends StatelessWidget {
           ],
         ),
       ),
-    );
+    ));
   }
 }
+

--- a/frontend/lib/features/navigation/edit_button.dart
+++ b/frontend/lib/features/navigation/edit_button.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/service/sound_effect_service.dart';
@@ -10,40 +10,47 @@ class EditButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      borderRadius: BorderRadius.circular(10),
-      child: InkWell(
+    return Semantics(
+      button: true,
+      label: '장소 추가',
+      enabled: onTap != null,
+      onTap: onTap,
+      excludeSemantics: true,
+      child: Material(
+        color: Colors.transparent,
         borderRadius: BorderRadius.circular(10),
-        onTap: onTap == null
-            ? null
-            : () {
-                SoundEffectService().play(SoundEffect.buttonTap);
-              VibrationService().vibrate(VibrationEffect.buttonTap);
-                onTap!();
-              },
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 18),
-          constraints: const BoxConstraints(minHeight: 75),
-          alignment: Alignment.center,
-          decoration: BoxDecoration(
-            color: ColorCollection.main.withOpacity(0.1),
-            borderRadius: BorderRadius.circular(10),
-            border: Border.all(color: ColorCollection.main, width: 1),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(Icons.add, color: ColorCollection.main, size: 30),
-              const SizedBox(width: 6),
-              Text(
-                '추가',
-                style: AppTextStyles.title2.copyWith(
-                  color: ColorCollection.main,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(10),
+          onTap: onTap == null
+              ? null
+              : () {
+                  SoundEffectService().play(SoundEffect.buttonTap);
+                  VibrationService().vibrate(VibrationEffect.buttonTap);
+                  onTap!();
+                },
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 18),
+            constraints: const BoxConstraints(minHeight: 75),
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: ColorCollection.main.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(color: ColorCollection.main, width: 1),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.add, color: ColorCollection.main, size: 30),
+                const SizedBox(width: 6),
+                Text(
+                  '추가',
+                  style: AppTextStyles.title2.copyWith(
+                    color: ColorCollection.main,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/frontend/lib/features/navigation/place_name_section.dart
+++ b/frontend/lib/features/navigation/place_name_section.dart
@@ -17,11 +17,14 @@ class PlaceNameSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '장소 이름 설정',
-          style: AppTextStyles.title2.copyWith(
-            color: ColorCollection.point,
-            fontSize: 20,
+        Semantics(
+          header: true,
+          child: Text(
+            '장소 이름 설정',
+            style: AppTextStyles.title2.copyWith(
+              color: ColorCollection.point,
+              fontSize: 20,
+            ),
           ),
         ),
         const SizedBox(height: 15),

--- a/frontend/lib/features/navigation/saved_place_screen.dart
+++ b/frontend/lib/features/navigation/saved_place_screen.dart
@@ -104,7 +104,12 @@ class _SavedPlaceScreenState extends State<SavedPlaceScreen> {
             children: [
               Expanded(
                 child: _isLoading
-                    ? const Center(child: CircularProgressIndicator())
+                    ? Center(
+                        child: Semantics(
+                          label: '로딩 중',
+                          child: const CircularProgressIndicator(),
+                        ),
+                      )
                     : _places.isEmpty && !isEditMode
                     ? Center(
                         child: Text(

--- a/frontend/lib/features/navigation/saved_place_widget.dart
+++ b/frontend/lib/features/navigation/saved_place_widget.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/common/enum/place_category.dart';
@@ -33,18 +33,20 @@ class SavedPlaceWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
+    final bool isTappable = !isEditMode && onTap != null;
+
+    final Widget card = Material(
       color: Colors.transparent,
       borderRadius: BorderRadius.circular(10),
       child: InkWell(
         borderRadius: BorderRadius.circular(10),
-        onTap: onTap == null
-            ? null
-            : () {
+        onTap: isTappable
+            ? () {
                 SoundEffectService().play(SoundEffect.buttonTap);
-              VibrationService().vibrate(VibrationEffect.buttonTap);
+                VibrationService().vibrate(VibrationEffect.buttonTap);
                 onTap!();
-              },
+              }
+            : null,
         child: Container(
           decoration: BoxDecoration(
             color: ColorCollection.point.withOpacity(0.1),
@@ -57,15 +59,18 @@ class SavedPlaceWidget extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 if (category != null) ...[
-                  Container(
-                    width: 35,
-                    height: 35,
-                    alignment: Alignment.center,
-                    decoration: BoxDecoration(
-                      color: iconBackgroundColor,
-                      borderRadius: BorderRadius.circular(5),
+                  // 아이콘은 label에 포함되므로 개별 읽기 제외
+                  ExcludeSemantics(
+                    child: Container(
+                      width: 35,
+                      height: 35,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: iconBackgroundColor,
+                        borderRadius: BorderRadius.circular(5),
+                      ),
+                      child: Icon(category?.icon, color: iconColor, size: 25),
                     ),
-                    child: Icon(category?.icon, color: iconColor, size: 25),
                   ),
                   const SizedBox(width: 14),
                 ],
@@ -93,43 +98,73 @@ class SavedPlaceWidget extends StatelessWidget {
                 ),
                 const SizedBox(width: 10),
                 if (isEditMode)
-                  GestureDetector(
+                  // 삭제 버튼은 카드와 독립된 별도 semantics 노드
+                  // Semantics.onTap: TalkBack 더블탭 시 ACTION_CLICK을 직접 수신
+                  Semantics(
+                    button: true,
+                    label: '$label 삭제',
+                    excludeSemantics: true,
                     onTap: onDelete == null
                         ? null
                         : () {
                             SoundEffectService().play(SoundEffect.buttonTap);
-              VibrationService().vibrate(VibrationEffect.buttonTap);
+                            VibrationService().vibrate(VibrationEffect.buttonTap);
                             onDelete!();
                           },
-                    child: Container(
-                      width: 50,
-                      height: 50,
-                      alignment: Alignment.center,
-                      decoration: BoxDecoration(
-                        color: ColorCollection.red,
-                        borderRadius: BorderRadius.circular(10),
-                        border: Border.all(
-                          color: ColorCollection.point,
-                          width: 1,
+                    child: GestureDetector(
+                      onTap: onDelete == null
+                          ? null
+                          : () {
+                              SoundEffectService().play(SoundEffect.buttonTap);
+                              VibrationService().vibrate(VibrationEffect.buttonTap);
+                              onDelete!();
+                            },
+                      child: Container(
+                        width: 50,
+                        height: 50,
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          color: ColorCollection.red,
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(
+                            color: ColorCollection.point,
+                            width: 1,
+                          ),
                         ),
-                      ),
-                      child: const Icon(
-                        Icons.delete,
-                        color: ColorCollection.point,
-                        size: 35,
+                        child: const Icon(
+                          Icons.delete,
+                          color: ColorCollection.point,
+                          size: 35,
+                        ),
                       ),
                     ),
                   )
                 else
-                  Icon(
-                    Icons.arrow_forward_ios_rounded,
-                    color: ColorCollection.main,
+                  // 화살표 아이콘은 장식용 — 개별 읽기 제외
+                  ExcludeSemantics(
+                    child: Icon(
+                      Icons.arrow_forward_ios_rounded,
+                      color: ColorCollection.main,
+                    ),
                   ),
               ],
             ),
           ),
         ),
       ),
+    );
+
+    // 일반 모드: 카드 전체를 하나의 버튼으로 읽힘
+    // 편집 모드: 카드는 비활성, 삭제 버튼이 별도 노드로 읽힘
+    if (isEditMode) return card;
+
+    return Semantics(
+      button: true,
+      label: '$label, $location',
+      enabled: onTap != null,
+      onTap: onTap,
+      excludeSemantics: true,
+      child: card,
     );
   }
 }


### PR DESCRIPTION
## 📎 Issue 번호
#95 

## 📄 작업 내용 요약
TalkBack 등 OS 스크린리더를 위한 Semantics 작업
- `saved_place_widget`: 일반 모드 - 카드 전체를 하나의 버튼으로 읽힘 / 편집 모드 - 삭제 버튼을 독립 버튼으로 분리, 카드 비활성화
- `edit_button`: 장소 추가 버튼 label 추가                                                                                      
- `category_item`: 버튼 label + 선택 상태(`selected`, `hint`) 추가
- `category_section` / `address_section` / `place_name_section`: 섹션 제목에 `header` semantics 추가
- `current_place_widget`: label + location 합쳐서 하나의 노드로 읽힘                                
- `saved_place_screen` / `add_place_screen`: 로딩 인디케이터에 label 추가

## ✅ 체크리스트
- [x] 빌드 및 실행이 정상 동작한다                                                                                                                                                                        
- [x] Breaking change 없음                                                                                                                                                                                
- [x] TalkBack 활성화 후 각 요소가 올바르게 읽히는지 확인
- [x] 커밋 메시지가 작업 내용과 일치한다                                                                                                                                                                  
- [x] 셀프 리뷰를 완료했다