### PR TITLE
[FEAT] 길찾기 화면 스크린리더 접근성(Semantics) 추가

### DIFF
--- a/frontend/lib/features/navigation/more_button.dart
+++ b/frontend/lib/features/navigation/more_button.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/routes/app_router.dart';
@@ -11,7 +11,11 @@ class MoreButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
+    return Semantics(
+      button: true,
+      label: '저장된 장소 더보기',
+      excludeSemantics: true,
+      child: Material(
       color: Colors.transparent,
       borderRadius: BorderRadius.circular(10),
       child: InkWell(
@@ -52,6 +56,7 @@ class MoreButton extends StatelessWidget {
           ),
         ),
       ),
+    ),
     );
   }
 }

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -650,25 +650,29 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                 child: Container(
                   color: ColorCollection.main.withValues(alpha: 0.9),
                   padding: const EdgeInsets.symmetric(vertical: 10),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: ColorCollection.point,
+                  child: Semantics(
+                    label: '경로 재탐색 중',
+                    excludeSemantics: true,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: ColorCollection.point,
+                          ),
                         ),
-                      ),
-                      const SizedBox(width: 10),
-                      Text(
-                        '경로 재탐색 중...',
-                        style: AppTextStyles.labelBold.copyWith(
-                          color: ColorCollection.point,
+                        const SizedBox(width: 10),
+                        Text(
+                          '경로 재탐색 중...',
+                          style: AppTextStyles.labelBold.copyWith(
+                            color: ColorCollection.point,
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -633,15 +633,17 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                 ],
               ),
             ),
-            RouteDebugOverlay(
-              pointSteps: _pointSteps,
-              currentStepIndex: _currentStepIndex,
-              distanceToStep: _debugDistance,
-              outsideThreshold: _hasBeenOutsideThreshold,
-              threshold: _arrivalThresholdMeters,
-              minDistanceToStep: _minDistanceToStep,
+            ExcludeSemantics(
+              child: RouteDebugOverlay(
+                pointSteps: _pointSteps,
+                currentStepIndex: _currentStepIndex,
+                distanceToStep: _debugDistance,
+                outsideThreshold: _hasBeenOutsideThreshold,
+                threshold: _arrivalThresholdMeters,
+                minDistanceToStep: _minDistanceToStep,
+              ),
             ),
-            const CameraDebugOverlay(anchorLeft: true),
+            const ExcludeSemantics(child: CameraDebugOverlay(anchorLeft: true)),
             if (_isRecalculating)
               Positioned(
                 top: 0,

--- a/frontend/lib/features/navigation/navigation_overview_card.dart
+++ b/frontend/lib/features/navigation/navigation_overview_card.dart
@@ -60,7 +60,12 @@ class NavigationOverviewCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final semanticLabel =
+        '총 거리 ${_formatDistance(distance)}, 총 소요시간 ${_formatTime(time)}, 경로 상태 ${_getStatusText(status)}';
+    return Semantics(
+      label: semanticLabel,
+      excludeSemantics: true,
+      child: Container(
       decoration: BoxDecoration(
         color: Colors.transparent,
         borderRadius: BorderRadius.circular(10),
@@ -140,6 +145,7 @@ class NavigationOverviewCard extends StatelessWidget {
           ],
         ),
       ),
+    ),
     );
   }
 }

--- a/frontend/lib/features/navigation/navigation_result_list.dart
+++ b/frontend/lib/features/navigation/navigation_result_list.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/service/sound_effect_service.dart';
@@ -71,9 +71,14 @@ class _ResultListState extends State<ResultList> {
         separatorBuilder: (_, __) => const Divider(height: 1),
         itemBuilder: (context, index) {
           if (index == widget.results.length) {
-            return const Padding(
-              padding: EdgeInsets.symmetric(vertical: 12),
-              child: Center(child: CircularProgressIndicator()),
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: Center(
+                child: Semantics(
+                  label: '불러오는 중',
+                  child: const CircularProgressIndicator(),
+                ),
+              ),
             );
           }
 

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -442,11 +442,14 @@ class _NavigationScreenState extends State<NavigationScreen> {
                       crossAxisAlignment: CrossAxisAlignment.center,
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text(
-                          '저장된 장소',
-                          style: AppTextStyles.title2.copyWith(
-                            color: ColorCollection.point,
-                            fontSize: 20,
+                        Semantics(
+                          header: true,
+                          child: Text(
+                            '저장된 장소',
+                            style: AppTextStyles.title2.copyWith(
+                              color: ColorCollection.point,
+                              fontSize: 20,
+                            ),
                           ),
                         ),
                         MoreButton(
@@ -520,11 +523,14 @@ class _NavigationScreenState extends State<NavigationScreen> {
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        Text(
-                          '최근 장소',
-                          style: AppTextStyles.title2.copyWith(
-                            color: ColorCollection.point,
-                            fontSize: 20,
+                        Semantics(
+                          header: true,
+                          child: Text(
+                            '최근 장소',
+                            style: AppTextStyles.title2.copyWith(
+                              color: ColorCollection.point,
+                              fontSize: 20,
+                            ),
                           ),
                         ),
                         if (_recentPlaces.isNotEmpty)
@@ -606,7 +612,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
                   left: 0,
                   right: 0,
                   child: isLoading
-                      ? const Center(child: CircularProgressIndicator())
+                      ? Center(child: Semantics(label: '검색 중', child: const CircularProgressIndicator()))
                       : searchResults.isNotEmpty
                       ? ResultList(
                           results: searchResults,
@@ -669,16 +675,20 @@ class _ClearButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      borderRadius: BorderRadius.circular(10),
-      child: InkWell(
+    return Semantics(
+      button: true,
+      label: '최근 장소 전체 삭제',
+      excludeSemantics: true,
+      child: Material(
+        color: Colors.transparent,
         borderRadius: BorderRadius.circular(10),
-        onTap: () {
-          SoundEffectService().play(SoundEffect.buttonTap);
-          VibrationService().vibrate(VibrationEffect.buttonTap);
-          onTap();
-        },
+        child: InkWell(
+          borderRadius: BorderRadius.circular(10),
+          onTap: () {
+            SoundEffectService().play(SoundEffect.buttonTap);
+            VibrationService().vibrate(VibrationEffect.buttonTap);
+            onTap();
+          },
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
           decoration: BoxDecoration(
@@ -704,6 +714,7 @@ class _ClearButton extends StatelessWidget {
           ),
         ),
       ),
+    ),
     );
   }
 }

--- a/frontend/lib/features/navigation/navigation_start_overview_card.dart
+++ b/frontend/lib/features/navigation/navigation_start_overview_card.dart
@@ -48,7 +48,16 @@ class NavigationStartOverviewCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final startLabel = startDirection != null
+        ? '$startDirection 방향으로 출발하세요'
+        : '길안내를 시작합니다';
+    final semanticLabel =
+        '$startLabel. 총 ${_formatDistance(totalDistance)}, 약 ${_formatTime(totalTime)}. '
+        '${_formatDistance(firstStepDistance)} 앞에서 ${_directionLabel(firstStepDirection)}하세요';
+    return Semantics(
+      label: semanticLabel,
+      excludeSemantics: true,
+      child: Container(
       decoration: BoxDecoration(
         color: ColorCollection.point.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(10),
@@ -92,6 +101,7 @@ class NavigationStartOverviewCard extends StatelessWidget {
           ),
         ],
       ),
+    ),
     );
   }
 }

--- a/frontend/lib/features/navigation/navigation_step_card.dart
+++ b/frontend/lib/features/navigation/navigation_step_card.dart
@@ -75,7 +75,16 @@ class NavigationStepCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final distDir = direction == DirectionType.straight
+        ? '${_formatDistance(distance)} 직진'
+        : '${_formatDistance(distance)} 후 ${_getDirectionLabel(direction)}';
+    final semanticLabel = instruction.isNotEmpty
+        ? '$distDir, $instruction. ${_getTtsMessage(direction, distance, instruction)}'
+        : '$distDir. ${_getTtsMessage(direction, distance, instruction)}';
+    return Semantics(
+      label: semanticLabel,
+      excludeSemantics: true,
+      child: Container(
       decoration: BoxDecoration(
         color: ColorCollection.point.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(10),
@@ -165,6 +174,7 @@ class NavigationStepCard extends StatelessWidget {
           ],
         ),
       ),
+    ),
     );
   }
 }

--- a/frontend/lib/features/navigation/navigation_voiceguide_card.dart
+++ b/frontend/lib/features/navigation/navigation_voiceguide_card.dart
@@ -10,7 +10,10 @@ class NavigationVoiceGuideCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DottedBorder(
+    return Semantics(
+      label: '주의, $voiceGuide',
+      excludeSemantics: true,
+      child: DottedBorder(
       borderType: BorderType.RRect,
       radius: const Radius.circular(10),
       dashPattern: const [4, 4], // 점 길이, 간격
@@ -54,6 +57,7 @@ class NavigationVoiceGuideCard extends StatelessWidget {
           ],
         ),
       ),
+    ),
     );
   }
 }


### PR DESCRIPTION
## 📎 Issue 번호
#95 

## 📄 작업 내용 요약
TalkBack 등 OS 스크린리더를 위한 Semantics 작업
- `navigation_screen` : 섹션 제목(저장된 장소 / 최근 장소)에 `header` semantics 추가, 전체 삭제 버튼 label 추가, 검색 중 로딩 인디케이터 label 추가                                                       
- `navigation_ing_screen` : 경로 재탐색 배너를 하나의 노드로 읽힘
- `navigation_overview_card` : 총 거리·소요시간·경로 상태를 하나의 노드로 읽힘                                                                                                                            
- `navigation_step_card` : 거리 + 방향 + 안내문 + TTS 메시지를 하나의 노드로 읽힘                                                                                                                         
- `navigation_start_overview_card` : 출발 방향·총 거리·소요시간·첫 스텝 정보를 하나의 노드로 읽힘                                                                                                         
- `navigation_voiceguide_card` : 주의 + 장애물 안내를 하나의 노드로 읽힘                                                                                                                                  
- `more_button` : 저장된 장소 더보기 버튼 label 추가                                                                                                                                                     - `navigation_result_list` : 무한 스크롤 로딩 인디케이터 label 추가

## ✅ 체크리스트
- [x] 빌드 및 실행이 정상 동작한다                                                                                                                                                                        
- [x] Breaking change 없음
- [x] TalkBack 활성화 후 각 요소가 올바르게 읽히는지 확인                                                                                                                                                 
- [x] 커밋 메시지가 작업 내용과 일치한다                                                                                                                                                                  
- [x] 셀프 리뷰를 완료했다

## 💬 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분, 우려 사항, 논의할 내용 등 -->