### PR TITLE
[FIX] route 디버그 오버레이 위치 재조정

### DIFF
--- a/frontend/lib/common/widgets/route_debug_overlay.dart
+++ b/frontend/lib/common/widgets/route_debug_overlay.dart
@@ -55,7 +55,7 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
       return Positioned(
         right: 8 + vp.right,
         top: 8 + vp.top,
-        child: GestureDetector(
+        child: ExcludeSemantics(child: GestureDetector(
           onTap: () => setState(() => _visible = true),
           child: Container(
             padding: const EdgeInsets.all(6),
@@ -65,14 +65,14 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
             ),
             child: const Icon(Icons.navigation, color: Colors.white, size: 18),
           ),
-        ),
+        )),
       );
     }
 
     return Positioned(
       right: 8 + vp.right,
       top: 8 + vp.top,
-      child: Column(
+      child: ExcludeSemantics(child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -153,7 +153,7 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
             ),
           ),
         ],
-      ),
+      )),
     );
   }
 }

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -633,17 +633,15 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                 ],
               ),
             ),
-            ExcludeSemantics(
-              child: RouteDebugOverlay(
-                pointSteps: _pointSteps,
-                currentStepIndex: _currentStepIndex,
-                distanceToStep: _debugDistance,
-                outsideThreshold: _hasBeenOutsideThreshold,
-                threshold: _arrivalThresholdMeters,
-                minDistanceToStep: _minDistanceToStep,
-              ),
+            RouteDebugOverlay(
+              pointSteps: _pointSteps,
+              currentStepIndex: _currentStepIndex,
+              distanceToStep: _debugDistance,
+              outsideThreshold: _hasBeenOutsideThreshold,
+              threshold: _arrivalThresholdMeters,
+              minDistanceToStep: _minDistanceToStep,
             ),
-            const ExcludeSemantics(child: CameraDebugOverlay(anchorLeft: true)),
+            const CameraDebugOverlay(anchorLeft: true),
             if (_isRecalculating)
               Positioned(
                 top: 0,


### PR DESCRIPTION
## 📎 Issue 번호
#95

## 📄 작업 내용 요약
route 디버그 오버레이가 camera 디버그 오버레이와 겹치는 문제 수정
- `route_debug_overlay` : `Positioned`의 위치 유지를 위해 외부가 아닌 내부 `child`에 `ExcludeSemantics` 적용 (visible / hidden 두 상태 모두)

## ✅ 체크리스트
- [x] 빌드 및 실행이 정상 동작한다                                                                                                                                                                        
- [x] Breaking change 없음                                                                                                                                                                              
- [x] RouteDebugOverlay 위치가 기존과 동일한지 확인                                                                                                                                                       
- [x] TalkBack 활성화 시 디버그 오버레이가 읽히지 않는지 확인                                                                                                                                             
- [x] 커밋 메시지가 작업 내용과 일치한다                                                                                                                                                                  
- [x] 셀프 리뷰를 완료했다
