### PR TITLE
[FIX] 길안내 스텝 진행 로직 개선 및 횡단보도 음성신호기 UI 추가

### DIFF
--- a/frontend/lib/common/widgets/route_debug_overlay.dart
+++ b/frontend/lib/common/widgets/route_debug_overlay.dart
@@ -27,6 +27,9 @@ class RouteDebugOverlay extends StatefulWidget {
   final bool outsideThreshold;
   final double threshold;
   final double minDistanceToStep;
+  final double? segmentDist;
+  final int deviationCount;
+  final int pathIndex;
 
   const RouteDebugOverlay({
     super.key,
@@ -36,6 +39,9 @@ class RouteDebugOverlay extends StatefulWidget {
     required this.outsideThreshold,
     required this.threshold,
     this.minDistanceToStep = double.infinity,
+    this.segmentDist,
+    this.deviationCount = 0,
+    this.pathIndex = 0,
   });
 
   @override
@@ -76,6 +82,20 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
+          // 이탈 감지 상태 표시
+          Container(
+            width: 210,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            color: Colors.black.withValues(alpha: 0.85),
+            child: Text(
+              'DEV  seg:${widget.segmentDist != null ? '${widget.segmentDist!.toStringAsFixed(1)}m' : '--'}  cnt:${widget.deviationCount}/3  path:${widget.pathIndex}',
+              style: TextStyle(
+                color: widget.deviationCount > 0 ? Colors.orange : Colors.cyan,
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
           // 헤더 (닫기 버튼)
           GestureDetector(
             onTap: () => setState(() => _visible = false),

--- a/frontend/lib/common/widgets/route_debug_overlay.dart
+++ b/frontend/lib/common/widgets/route_debug_overlay.dart
@@ -55,7 +55,7 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
       return Positioned(
         right: 8 + vp.right,
         top: 8 + vp.top,
-        child: GestureDetector(
+        child: ExcludeSemantics(child: GestureDetector(
           onTap: () => setState(() => _visible = true),
           child: Container(
             padding: const EdgeInsets.all(6),
@@ -65,14 +65,14 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
             ),
             child: const Icon(Icons.navigation, color: Colors.white, size: 18),
           ),
-        ),
+        )),
       );
     }
 
     return Positioned(
       right: 8 + vp.right,
       top: 8 + vp.top,
-      child: Column(
+      child: ExcludeSemantics(child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -153,7 +153,7 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
             ),
           ),
         ],
-      ),
+      )),
     );
   }
 }

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -63,6 +63,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   int _deviationCount = 0;
   bool _isRecalculating = false;
   int _currentPathIndex = 0;
+  double? _lastSegmentDist;
 
   // 횡단보도 음성신호기 캐시 (step index → CrosswalkInfo?)
   Map<int, CrosswalkInfo?> _crosswalkCache = {};
@@ -283,7 +284,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     final inPassThroughZone =
         _hasBeenOutsideThreshold && _minDistanceToStep < _arrivalThresholdMeters;
 
-    if (!inPassThroughZone) {
+    if (!inPassThroughZone || distance <= (_debugDistance ?? double.infinity)) {
       setState(() => _debugDistance = distance);
     }
 
@@ -317,15 +318,11 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         NavigationTtsService().speakDistance(direction, distance.round(), step.description ?? '');
       }
     } else if (_hasBeenOutsideThreshold) {
-      // pass-through zone — 거리 증가 안내 방지를 위해 speakDistance 호출하지 않음
+      // pass-through zone — 8m 이하 행동 지시 허용 (dedup은 speakDistance 내부에서 처리)
+      NavigationTtsService().speakDistance(direction, distance.round(), step.description ?? '');
     } else {
-      // 처음부터 10m 이내 → 이미 지난 step으로 간주하고 skip (TTS 없음)
-      setState(() {
-        _currentStepIndex++;
-        _minDistanceToStep = double.infinity;
-        _debugDistance = null;
-      });
-      _speakNextStepOrDestination();
+      // 처음부터 _arrivalThresholdMeters 이내 → pass-through zone 즉시 활성화
+      _hasBeenOutsideThreshold = true;
     }
 
     _checkDeviation(position);
@@ -425,6 +422,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     if (closestSegIndex > _currentPathIndex) {
       _currentPathIndex = closestSegIndex;
     }
+    _lastSegmentDist = minDist;
 
     if (minDist > _deviationThresholdMeters) {
       _deviationCount++;
@@ -598,6 +596,12 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                                 startDirection: _startDirection,
                               );
                             } else if (currentStep != null) {
+                              final crosswalk = _crosswalkCache[_currentStepIndex];
+                              final acousticSignal =
+                                  (crosswalk?.acousticSignalInstalled == true &&
+                                          crosswalk!.guidanceSummary.isNotEmpty)
+                                      ? crosswalk.guidanceSummary
+                                      : null;
                               return NavigationStepCard(
                                 direction: _turnTypeToDirection(
                                   currentStep.turnType,
@@ -605,6 +609,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                                 instruction: currentStep.description ?? '',
                                 distance: _debugDistance?.round() ?? 0,
                                 isApproaching: _hasBeenOutsideThreshold,
+                                acousticSignal: acousticSignal,
                               );
                             } else if (_hasArrived) {
                               return Center(
@@ -677,6 +682,9 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
               outsideThreshold: _hasBeenOutsideThreshold,
               threshold: _arrivalThresholdMeters,
               minDistanceToStep: _minDistanceToStep,
+              segmentDist: _lastSegmentDist,
+              deviationCount: _deviationCount,
+              pathIndex: _currentPathIndex,
             ),
             const CameraDebugOverlay(anchorLeft: true),
             if (_isRecalculating)

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -46,7 +46,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   double? _endY;
   String _endName = '';
 
-  static const double _arrivalThresholdMeters = 10;
+  static const double _arrivalThresholdMeters = 15;
   static const double _passThroughOffsetMeters = 8;
   bool _hasBeenOutsideThreshold = false;
   double _minDistanceToStep = double.infinity;
@@ -62,6 +62,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   static const int _deviationCountThreshold = 3;
   int _deviationCount = 0;
   bool _isRecalculating = false;
+  int _currentPathIndex = 0;
 
   // 횡단보도 음성신호기 캐시 (step index → CrosswalkInfo?)
   Map<int, CrosswalkInfo?> _crosswalkCache = {};
@@ -376,18 +377,53 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     }
   }
 
+  // 점 P에서 선분 AB까지의 최단 거리 (미터)
+  double _distanceToSegment(
+    double lat, double lng,
+    double lat1, double lng1,
+    double lat2, double lng2,
+  ) {
+    const double metersPerDegLat = 111320.0;
+    final double metersPerDegLng =
+        111320.0 * math.cos(lat * math.pi / 180);
+
+    final double px = (lng - lng1) * metersPerDegLng;
+    final double py = (lat - lat1) * metersPerDegLat;
+    final double ax = (lng2 - lng1) * metersPerDegLng;
+    final double ay = (lat2 - lat1) * metersPerDegLat;
+
+    final double segLenSq = ax * ax + ay * ay;
+    if (segLenSq == 0) {
+      return Geolocator.distanceBetween(lat, lng, lat1, lng1);
+    }
+
+    final double t = math.max(0, math.min(1, (px * ax + py * ay) / segLenSq));
+    final double dx = px - ax * t;
+    final double dy = py - ay * t;
+    return math.sqrt(dx * dx + dy * dy);
+  }
+
   void _checkDeviation(Position position) {
-    if (_routePath.isEmpty || _isRecalculating) return;
+    if (_routePath.length < 2 || _isRecalculating) return;
 
     double minDist = double.infinity;
-    for (final point in _routePath) {
-      final d = Geolocator.distanceBetween(
-        position.latitude,
-        position.longitude,
-        point.latitude,
-        point.longitude,
+    int closestSegIndex = _currentPathIndex;
+
+    for (int i = _currentPathIndex; i < _routePath.length - 1; i++) {
+      final d = _distanceToSegment(
+        position.latitude, position.longitude,
+        _routePath[i].latitude, _routePath[i].longitude,
+        _routePath[i + 1].latitude, _routePath[i + 1].longitude,
       );
-      if (d < minDist) minDist = d;
+      if (d < minDist) {
+        minDist = d;
+        closestSegIndex = i;
+      }
+    }
+
+    // 경로 인덱스는 앞으로만 전진
+    if (closestSegIndex > _currentPathIndex) {
+      _currentPathIndex = closestSegIndex;
     }
 
     if (minDist > _deviationThresholdMeters) {
@@ -435,6 +471,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         _hasArrived = false;
         _isRecalculating = false;
         _crosswalkCache = {};
+        _currentPathIndex = 0;
       });
       _loadRoute(result);
       // 재탐색 후 overview 카드 없이 새 경로 첫 step 바로 안내

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -670,17 +670,15 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                 ],
               ),
             ),
-            ExcludeSemantics(
-              child: RouteDebugOverlay(
-                pointSteps: _pointSteps,
-                currentStepIndex: _currentStepIndex,
-                distanceToStep: _debugDistance,
-                outsideThreshold: _hasBeenOutsideThreshold,
-                threshold: _arrivalThresholdMeters,
-                minDistanceToStep: _minDistanceToStep,
-              ),
+            RouteDebugOverlay(
+              pointSteps: _pointSteps,
+              currentStepIndex: _currentStepIndex,
+              distanceToStep: _debugDistance,
+              outsideThreshold: _hasBeenOutsideThreshold,
+              threshold: _arrivalThresholdMeters,
+              minDistanceToStep: _minDistanceToStep,
             ),
-            const ExcludeSemantics(child: CameraDebugOverlay(anchorLeft: true)),
+            const CameraDebugOverlay(anchorLeft: true),
             if (_isRecalculating)
               Positioned(
                 top: 0,

--- a/frontend/lib/features/navigation/navigation_step_card.dart
+++ b/frontend/lib/features/navigation/navigation_step_card.dart
@@ -14,6 +14,7 @@ class NavigationStepCard extends StatelessWidget {
   final String instruction;
   final int? distance;
   final bool isApproaching;
+  final String? acousticSignal;
 
   const NavigationStepCard({
     super.key,
@@ -21,6 +22,7 @@ class NavigationStepCard extends StatelessWidget {
     required this.instruction,
     this.distance,
     this.isApproaching = true,
+    this.acousticSignal,
   });
 
   IconData _getDirectionIcon(DirectionType direction) {
@@ -171,6 +173,39 @@ class NavigationStepCard extends StatelessWidget {
                 ],
               ),
             ),
+            if (acousticSignal != null && acousticSignal!.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 16),
+                decoration: BoxDecoration(
+                  color: ColorCollection.main.withValues(alpha: 0.5),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Icon(
+                      Icons.campaign_rounded,
+                      color: ColorCollection.point,
+                      size: 35,
+                    ),
+                    const SizedBox(width: 7),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          acousticSignal!,
+                          style: AppTextStyles.labelBold.copyWith(
+                            color: ColorCollection.point,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ],
         ),
       ),


### PR DESCRIPTION
## 📎 Issue 번호
#96 

## 📄 작업 내용 요약
길안내 중 스텝 진행 로직의 구조적 문제 수정 및 횡단보도 음성신호기 정보 UI 추가                                                                                                                           

  **경로 이탈 감지 개선**                                                                                                                                                                                   
  - `_distanceToSegment()` 추가: 기존 좌표점 기준 거리 → 선분 기준 거리로 변경, 경로 좌표가 성긴 구간에서 정상 이동 중 오탐 방지                                                                          
  - `_currentPathIndex` 추가: 이탈 감지 시 이미 지나온 선분은 제외하고 앞쪽 경로만 검사, 지나온 경로 좌표로 인한 이탈 미감지 문제 해결                                                                      
  - 재탐색 시 `_currentPathIndex` 리셋 처리                                                                                                                                                                 
                                                                                                                                                                                                            
  **스텝 진행 로직 수정**                                                                                                                                                                                   
  - `_arrivalThresholdMeters`: 10m → 15m 완화 (GPS 오차 환경에서 pass-through zone 미진입 문제 대응)                                                                                                        
  - 15m 이내 진입 후 거리가 다시 증가할 때 UI 업데이트 및 TTS 안내 누락되던 문제 수정                                                                                                                       
  - 처음부터 threshold 이내에서 시작하는 스텝을 즉시 skip하던 로직 제거 → pass-through zone 즉시 활성화로 교체 (횡단보도 등 중간 스텝 skip 방지)                                                            
                                                                                                                                                                                                            
  **횡단보도 음성신호기 UI**                                                                                                                                                                                
  - `NavigationStepCard`에 `acousticSignal` 파라미터 추가                                                                                                                                                   
  - 음성신호기가 있는 횡단보도 스텝에서 TTS 박스 하단에 안내 박스 표시, 스텝 통과 시 자동으로 사라짐                                                                                                        
                                                                                                                                                                                                            
  **디버그 기능**                                                                                                                                                                                           
  - `RouteDebugOverlay` 최상단에 `seg`(현재 선분 거리) / `cnt`(이탈 카운트) / `path`(경로 인덱스) 표시 추가, 필드 테스트 중 이탈 감지 상태 실시간 확인 가능

## ✅ 체크리스트
- [x] 빌드 및 실행이 정상 동작한다                                                                                                                                                                        
- [x] Breaking change 없음
- [x] 실제 보행 테스트로 이탈 감지 및 재탐색 동작 확인                                                                                                                                                    
- [x] 짧은 스텝(~13m)에서 pass-through 정상 동작 확인                                                                                                                                                     
- [x] 커밋 메시지가 작업 내용과 일치한다                                                                                                                                                                  
- [x] 셀프 리뷰를 완료했다

## 💬 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분, 우려 사항, 논의할 내용 등 -->