### PR TITLE
[FEAT] 길찾기 전용 모드 분리 및 하단 탭 추가

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -40,6 +40,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   int _currentStepIndex = 0;
   StreamSubscription<Position>? _positionSub;
   bool _routeLoaded = false;
+  bool _withObstacleDetection = true;
 
   // 목적지 정보 (재탐색 시 사용)
   double? _endX;
@@ -93,13 +94,14 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
         _endX = args['endX'] as double?;
         _endY = args['endY'] as double?;
         _endName = (args['endName'] as String?) ?? '';
+        _withObstacleDetection = (args['withObstacleDetection'] as bool?) ?? true;
       } else {
         _route = args as RouteResult?;
       }
       if (_route != null) {
         _loadRoute(_route!);
         _startLocationTracking();
-        _startObstacleDetection();
+        if (_withObstacleDetection) _startObstacleDetection();
         _routeLoaded = true;
       }
     }
@@ -491,9 +493,11 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   void dispose() {
     NavigationTtsService().reset();
     _positionSub?.cancel();
-    _wsSub?.cancel();
-    CameraService().stop();
-    DetectionWsService().disconnect();
+    if (_withObstacleDetection) {
+      _wsSub?.cancel();
+      CameraService().stop();
+      DetectionWsService().disconnect();
+    }
     TtsService().stop();
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
@@ -646,8 +650,8 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                             return const SizedBox.shrink();
                           }(),
                         ),
-                        // 장애물 안내 목록 — 스크롤 (최신 순)
-                        if (_obstacles.isNotEmpty) ...[
+                        // 장애물 안내 목록 — 스크롤 (최신 순, 통합 모드에서만 표시)
+                        if (_withObstacleDetection && _obstacles.isNotEmpty) ...[
                           const SizedBox(height: 12),
                           Expanded(
                             child: ListView.separated(
@@ -686,7 +690,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
               deviationCount: _deviationCount,
               pathIndex: _currentPathIndex,
             ),
-            const CameraDebugOverlay(anchorLeft: true),
+            if (_withObstacleDetection) const CameraDebugOverlay(anchorLeft: true),
             if (_isRecalculating)
               Positioned(
                 top: 0,

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -19,7 +19,9 @@ import 'package:safepath/service/sound_effect_service.dart';
 import 'package:safepath/service/vibration_service.dart';
 
 class NavigationScreen extends StatefulWidget {
-  const NavigationScreen({super.key});
+  final bool withObstacleDetection;
+
+  const NavigationScreen({super.key, this.withObstacleDetection = true});
 
   @override
   State<NavigationScreen> createState() => _NavigationScreenState();
@@ -247,6 +249,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
           'endX': _selectedLng!,
           'endY': _selectedLat!,
           'endName': _selectedName,
+          'withObstacleDetection': widget.withObstacleDetection,
         },
       );
 

--- a/frontend/lib/layout/layout.dart
+++ b/frontend/lib/layout/layout.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/features/detection/detection_screen.dart';
 import 'package:safepath/features/home/home_screen.dart';
@@ -22,8 +22,11 @@ class _MainLayoutState extends State<MainLayout> {
 
   late final List<Widget> _pages = [
     HomeScreen(onTabChange: _onTap),
-    DetectionScreen(onDetectingChanged: (v) => setState(() => _isDetecting = v)),
-    const NavigationScreen(),
+    DetectionScreen(
+      onDetectingChanged: (v) => setState(() => _isDetecting = v),
+    ),
+    const NavigationScreen(withObstacleDetection: false),
+    const NavigationScreen(withObstacleDetection: true),
     SettingsScreen(scrollController: _settingsScrollController),
   ];
 
@@ -35,7 +38,7 @@ class _MainLayoutState extends State<MainLayout> {
 
   void _onTap(int index) {
     // 설정 탭으로 진입할 때 스크롤 top으로 리셋
-    if (index == 3 && _settingsScrollController.hasClients) {
+    if (index == 4 && _settingsScrollController.hasClients) {
       _settingsScrollController.jumpTo(0);
     }
     setState(() {
@@ -56,46 +59,57 @@ class _MainLayoutState extends State<MainLayout> {
       },
       child: Scaffold(
         body: IndexedStack(index: _currentIndex, children: _pages),
-      bottomNavigationBar: _isDetecting ? null : Container(
-        decoration: const BoxDecoration(
-          border: Border(
-            top: BorderSide(color: ColorCollection.point, width: 1.0),
-          ),
-        ),
-        child: BottomNavigationBar(
-          currentIndex: _currentIndex,
-          onTap: (index) {
-            SoundEffectService().play(SoundEffect.buttonTap);
-              VibrationService().vibrate(VibrationEffect.buttonTap);
-            _onTap(index);
-          },
-          type: BottomNavigationBarType.fixed,
-          backgroundColor: ColorCollection.background,
-          selectedItemColor: ColorCollection.main,
-          selectedLabelStyle: const TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-            fontFamily: 'NanumSquareNeo',
-          ),
-          unselectedLabelStyle: const TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.w500,
-            fontFamily: 'NanumSquareNeo',
-          ),
-          unselectedItemColor: ColorCollection.point,
-          items: const [
-            BottomNavigationBarItem(icon: Icon(Icons.home), label: '홈'),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.remove_red_eye_outlined),
-              label: '탐지',
-            ),
-            BottomNavigationBarItem(icon: Icon(Icons.navigation), label: '길찾기'),
-            BottomNavigationBarItem(icon: Icon(Icons.settings), label: '설정'),
-          ],
-        ),
-      ),
+        bottomNavigationBar: _isDetecting
+            ? null
+            : Container(
+                decoration: const BoxDecoration(
+                  border: Border(
+                    top: BorderSide(color: ColorCollection.point, width: 1.0),
+                  ),
+                ),
+                child: BottomNavigationBar(
+                  currentIndex: _currentIndex,
+                  onTap: (index) {
+                    SoundEffectService().play(SoundEffect.buttonTap);
+                    VibrationService().vibrate(VibrationEffect.buttonTap);
+                    _onTap(index);
+                  },
+                  type: BottomNavigationBarType.fixed,
+                  backgroundColor: ColorCollection.background,
+                  selectedItemColor: ColorCollection.main,
+                  selectedLabelStyle: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    fontFamily: 'NanumSquareNeo',
+                  ),
+                  unselectedLabelStyle: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    fontFamily: 'NanumSquareNeo',
+                  ),
+                  unselectedItemColor: ColorCollection.point,
+                  items: const [
+                    BottomNavigationBarItem(icon: Icon(Icons.home), label: '홈'),
+                    BottomNavigationBarItem(
+                      icon: Icon(Icons.remove_red_eye_outlined),
+                      label: '탐지',
+                    ),
+                    BottomNavigationBarItem(
+                      icon: Icon(Icons.navigation),
+                      label: '길찾기',
+                    ),
+                    BottomNavigationBarItem(
+                      icon: Icon(Icons.directions_walk_rounded),
+                      label: '통합',
+                    ),
+                    BottomNavigationBarItem(
+                      icon: Icon(Icons.settings),
+                      label: '설정',
+                    ),
+                  ],
+                ),
+              ),
       ),
     );
   }
 }
-


### PR DESCRIPTION
## 📎 Issue 번호
#73 

## 📄 작업 내용 요약
기존 통합 길찾기(길찾기+장애물탐지)에서 길찾기 기능만 분리하여 별도 탭으로 추가                                                                                                                         
                                                                                                                                                                                                       
  **하단 네비게이션 변경**
  - 기존 "길찾기" 탭 → "통합" 으로 이름 변경 (길찾기 + 장애물 탐지)                                                                                                                                         
  - "길찾기" 탭 신규 추가 (경로 안내만, 카메라 미사용)                                                                                                                                                    
  - 탭 구성: 홈 / 탐지 / 길찾기 / 통합 / 설정 (4개 → 5개)                                                                                                                                                   
                                                                                                                                                                                                            
  **구현 방식**                                                                                                                                                                                             
  - 새 화면 파일 생성 없이 `withObstacleDetection` 파라미터 하나로 분기 처리                                                                                                                                
  - `NavigationScreen`: 파라미터를 `NavigationIngScreen`으로 전달                                                                                                                                           
  - `NavigationIngScreen`: `false`일 때 카메라 시작·dispose·장애물 목록 UI·CameraDebugOverlay 비활성화 

## 📸 스크린샷 (UI 변경 시 작성, 없으면 삭제)
<img width=50% alt="0510_3" src="https://github.com/user-attachments/assets/1e369494-b923-45ab-8e22-edcb5fd92e24" />
<img width="2340" height="1080" alt="0510_4" src="https://github.com/user-attachments/assets/a5227b3b-45bc-414a-b6cc-e1a6db80d470" />



## ✅ 체크리스트

- [ ] 빌드 및 실행이 정상 동작한다
- [ ] Breaking change 없음 (있다면 작업 내용 요약에 명시)
- [ ] 테스트를 했거나, 기존 테스트로 충분하다
- [ ] 커밋 메시지가 작업 내용과 일치한다
- [ ] 셀프 리뷰를 완료했다
