### PR TITLE
[FIX] 길안내 디버그 오버레이 pass 값 고정 문제 및 null 거리 표시 수정

### DIFF
--- a/frontend/lib/common/widgets/route_debug_overlay.dart
+++ b/frontend/lib/common/widgets/route_debug_overlay.dart
@@ -27,6 +27,7 @@ class RouteDebugOverlay extends StatefulWidget {
   final bool outsideThreshold;
   final double threshold;
   final double minDistanceToStep;
+  final double? rawDistance;
   final double? segmentDist;
   final int deviationCount;
   final int pathIndex;
@@ -39,6 +40,7 @@ class RouteDebugOverlay extends StatefulWidget {
     required this.outsideThreshold,
     required this.threshold,
     this.minDistanceToStep = double.infinity,
+    this.rawDistance,
     this.segmentDist,
     this.deviationCount = 0,
     this.pathIndex = 0,
@@ -160,6 +162,9 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
                       distanceToStep: i == widget.currentStepIndex
                           ? widget.distanceToStep
                           : null,
+                      rawDistance: i == widget.currentStepIndex
+                          ? widget.rawDistance
+                          : null,
                       outsideThreshold: i == widget.currentStepIndex
                           ? widget.outsideThreshold
                           : null,
@@ -182,6 +187,7 @@ class _StepDebugCard extends StatelessWidget {
   final RouteStep step;
   final bool isCurrent;
   final double? distanceToStep;
+  final double? rawDistance;
   final bool? outsideThreshold;
   final double threshold;
   final double minDistanceToStep;
@@ -192,6 +198,7 @@ class _StepDebugCard extends StatelessWidget {
     required this.distanceToStep,
     required this.outsideThreshold,
     required this.threshold,
+    this.rawDistance,
     this.minDistanceToStep = double.infinity,
   });
 
@@ -304,7 +311,7 @@ class _StepDebugCard extends StatelessWidget {
                     ),
                     if (minDistanceToStep != double.infinity && outsideThreshold == true)
                       Text(
-                        'pass: ${(distanceToStep! - minDistanceToStep).toStringAsFixed(1)}/8m',
+                        'pass: ${((rawDistance ?? distanceToStep ?? minDistanceToStep) - minDistanceToStep).toStringAsFixed(1)}/8m',
                         style: const TextStyle(color: Colors.cyan, fontSize: 9),
                       ),
                   ],

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -52,6 +52,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   bool _hasBeenOutsideThreshold = false;
   double _minDistanceToStep = double.infinity;
   double? _debugDistance;
+  double? _rawDistance; // freeze 없이 항상 갱신되는 실제 GPS 거리
   bool _hasArrived = false;
   bool _showStartOverview = false;
   bool _hasShownStartOverview = false;
@@ -286,6 +287,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
     final inPassThroughZone =
         _hasBeenOutsideThreshold && _minDistanceToStep < _arrivalThresholdMeters;
 
+    _rawDistance = distance;
     if (!inPassThroughZone || distance <= (_debugDistance ?? double.infinity)) {
       setState(() => _debugDistance = distance);
     }
@@ -611,7 +613,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                                   currentStep.turnType,
                                 ),
                                 instruction: currentStep.description ?? '',
-                                distance: _debugDistance?.round() ?? 0,
+                                distance: _debugDistance?.round(),
                                 isApproaching: _hasBeenOutsideThreshold,
                                 acousticSignal: acousticSignal,
                               );
@@ -686,6 +688,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
               outsideThreshold: _hasBeenOutsideThreshold,
               threshold: _arrivalThresholdMeters,
               minDistanceToStep: _minDistanceToStep,
+              rawDistance: _rawDistance,
               segmentDist: _lastSegmentDist,
               deviationCount: _deviationCount,
               pathIndex: _currentPathIndex,


### PR DESCRIPTION
## 📎 Issue 번호
#96 

## 📄 작업 내용 요약
 pass-through zone 진입 후 디버그 정보가 고정되는 문제 수정                                                                                                                                              
                                                                                                                                                                                                            
  **문제**
  - 스텝 전환 직후 거리가 null임에도 0m로 표시됨                                                                                                                                                            
  - pass-through zone 진입 후 `pass: X.X/8m` 값이 0.0에서 고정되어 진행 상황 확인 불가                                                                                                                    
    - 원인: pass 계산에 사용하는 `distanceToStep`이 _debugDistance(freeze된 값)와 동일했기 때문                                                                                                             
                                                                                                                                                                                                            
  **수정**                                                                                                                                                                                                  
  - `_debugDistance?.round() ?? 0` → `_debugDistance?.round()` 변경, null일 때 "--m"으로 표시                                                                                                               
  - `_rawDistance` 추가: pass-through zone freeze 로직과 무관하게 항상 실제 GPS 거리 저장                                                                                                                   
  - `RouteDebugOverlay`의 pass 계산을 `rawDistance` 기반으로 변경, 웨이포인트에서 멀어질수록 실시간으로 증가하여 스텝 전환 시점 예측 가능

## ✅ 체크리스트

- [ ] 빌드 및 실행이 정상 동작한다
- [ ] Breaking change 없음 (있다면 작업 내용 요약에 명시)
- [ ] 테스트를 했거나, 기존 테스트로 충분하다
- [ ] 커밋 메시지가 작업 내용과 일치한다
- [ ] 셀프 리뷰를 완료했다
