### PR TITLE
[FIX] 길안내 GPS 스트림 미수신 및 위치 초기화 버그 수정

### DIFF
--- a/frontend/lib/common/widgets/route_debug_overlay.dart
+++ b/frontend/lib/common/widgets/route_debug_overlay.dart
@@ -31,6 +31,7 @@ class RouteDebugOverlay extends StatefulWidget {
   final double? segmentDist;
   final int deviationCount;
   final int pathIndex;
+  final double? gpsAccuracy;
 
   const RouteDebugOverlay({
     super.key,
@@ -44,6 +45,7 @@ class RouteDebugOverlay extends StatefulWidget {
     this.segmentDist,
     this.deviationCount = 0,
     this.pathIndex = 0,
+    this.gpsAccuracy,
   });
 
   @override
@@ -90,9 +92,9 @@ class _RouteDebugOverlayState extends State<RouteDebugOverlay> {
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             color: Colors.black.withValues(alpha: 0.85),
             child: Text(
-              'DEV  seg:${widget.segmentDist != null ? '${widget.segmentDist!.toStringAsFixed(1)}m' : '--'}  cnt:${widget.deviationCount}/3  path:${widget.pathIndex}',
+              'DEV  acc:${widget.gpsAccuracy != null ? '${widget.gpsAccuracy!.toStringAsFixed(1)}m' : '--'}  seg:${widget.segmentDist != null ? '${widget.segmentDist!.toStringAsFixed(1)}m' : '--'}  cnt:${widget.deviationCount}/3',
               style: TextStyle(
-                color: widget.deviationCount > 0 ? Colors.orange : Colors.cyan,
+                color: (widget.gpsAccuracy != null && widget.gpsAccuracy! > 20) ? Colors.red : (widget.deviationCount > 0 ? Colors.orange : Colors.cyan),
                 fontSize: 10,
                 fontWeight: FontWeight.bold,
               ),

--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -53,6 +53,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   double _minDistanceToStep = double.infinity;
   double? _debugDistance;
   double? _rawDistance; // freeze 없이 항상 갱신되는 실제 GPS 거리
+  double? _lastGpsAccuracy;
   bool _hasArrived = false;
   bool _showStartOverview = false;
   bool _hasShownStartOverview = false;
@@ -251,16 +252,23 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
   }
 
   void _startLocationTracking() {
+    debugPrint('🗺️ [GPS] 위치 추적 시작');
+    // navigation_screen이 pushNamed 전에 스트림을 취소하므로 딜레이 불필요
     _positionSub = Geolocator.getPositionStream(
       locationSettings: AndroidSettings(
         accuracy: LocationAccuracy.best,
         distanceFilter: 0,
         intervalDuration: Duration.zero,
       ),
-    ).listen(_onPositionUpdate);
+    ).listen(
+      _onPositionUpdate,
+      onError: (e) => debugPrint('🔴 [GPS] 스트림 에러: $e'),
+    );
   }
 
   void _onPositionUpdate(Position position) {
+    _lastGpsAccuracy = position.accuracy;
+    debugPrint('📍 [GPS] 위치 수신 acc:${position.accuracy.toStringAsFixed(1)}m');
     if (position.accuracy > 20) return;
 
     if (_currentStepIndex >= _pointSteps.length) {
@@ -718,6 +726,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
               segmentDist: _lastSegmentDist,
               deviationCount: _deviationCount,
               pathIndex: _currentPathIndex,
+              gpsAccuracy: _lastGpsAccuracy,
             ),
             if (_withObstacleDetection) const CameraDebugOverlay(anchorLeft: true),
             if (_isRecalculating)

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -40,6 +40,7 @@ class NavigationScreenState extends State<NavigationScreen>
 
   /// 위치 변수
   String currentLocation = "현재 위치 불러오는 중...";
+  bool _locationFailed = false;
   String selectedLocation = "목적지를 선택해 주세요.";
   double? _selectedLat;
   double? _selectedLng;
@@ -77,7 +78,6 @@ class NavigationScreenState extends State<NavigationScreen>
     });
   }
 
-  /// MainLayout이 온보딩 완료 후 또는 길찾기 탭 전환 시 호출.
   /// 최초 1회만 실행하며, 앱 재개 시 retry는 didChangeAppLifecycleState가 담당.
   void initLocationIfNeeded() {
     if (_locationInitialized || !mounted) return;
@@ -125,7 +125,8 @@ class NavigationScreenState extends State<NavigationScreen>
     }
 
     try {
-      final position = await getCurrentLocation();
+      final position = await getCurrentLocation()
+          .timeout(const Duration(seconds: 30));
       if (!mounted) return;
       _currentPosition = position;
       await _fetchAddress(position);
@@ -144,7 +145,10 @@ class NavigationScreenState extends State<NavigationScreen>
       });
     } catch (e) {
       debugPrint('🔴 위치 초기화 실패: $e');
-      if (mounted) setState(() => currentLocation = '현재 위치 불러오는 중...');
+      if (mounted) setState(() {
+        currentLocation = '현재 위치를 가져올 수 없습니다';
+        _locationFailed = true;
+      });
     }
   }
 
@@ -273,7 +277,6 @@ class NavigationScreenState extends State<NavigationScreen>
     SoundEffectService().play(SoundEffect.actionStart);
     VibrationService().vibrate(VibrationEffect.actionStart);
 
-    _positionStream?.cancel();
     setState(() => isLoading = true);
 
     try {
@@ -285,6 +288,12 @@ class NavigationScreenState extends State<NavigationScreen>
         startName: currentLocation,
         endName: _selectedName,
       );
+
+      if (!mounted) return;
+
+      // navigation_ing_screen이 열리기 전에 스트림을 취소해야 geolocator 스트림 충돌 방지
+      await _positionStream?.cancel();
+      _positionStream = null;
 
       if (!mounted) return;
 
@@ -310,6 +319,7 @@ class NavigationScreenState extends State<NavigationScreen>
         _selectedName = '';
         currentLocation = "현재 위치 불러오는 중...";
       });
+      _locationInitialized = false;
       _initLocation();
     } catch (e) {
       debugPrint('🔴 [Navigation] 길찾기 오류: $e');
@@ -345,11 +355,14 @@ class NavigationScreenState extends State<NavigationScreen>
         ),
       ).firstWhere((p) => p.accuracy <= 20).timeout(const Duration(seconds: 10));
     } catch (_) {
-      final last = await Geolocator.getLastKnownPosition();
-      if (last != null) return last;
+      try {
+        final last = await Geolocator.getLastKnownPosition()
+            .timeout(const Duration(seconds: 5));
+        if (last != null) return last;
+      } catch (_) {}
       return await Geolocator.getCurrentPosition(
         desiredAccuracy: LocationAccuracy.best,
-      );
+      ).timeout(const Duration(seconds: 10));
     }
   }
 
@@ -462,9 +475,27 @@ class NavigationScreenState extends State<NavigationScreen>
                       },
                     ),
                     const SizedBox(height: 16),
-                    CurrentPlaceWidget(
-                      label: '현재 위치',
-                      location: currentLocation,
+                    Row(
+                      children: [
+                        Expanded(
+                          child: CurrentPlaceWidget(
+                            label: '현재 위치',
+                            location: currentLocation,
+                          ),
+                        ),
+                        if (_locationFailed)
+                          IconButton(
+                            icon: const Icon(Icons.refresh),
+                            tooltip: '위치 재시도',
+                            onPressed: () {
+                              setState(() {
+                                currentLocation = '현재 위치 불러오는 중...';
+                                _locationFailed = false;
+                              });
+                              _initLocation();
+                            },
+                          ),
+                      ],
                     ),
                     const SizedBox(height: 16),
                     CurrentPlaceWidget(

--- a/frontend/lib/layout/layout.dart
+++ b/frontend/lib/layout/layout.dart
@@ -27,7 +27,7 @@ class _MainLayoutState extends State<MainLayout> {
     DetectionScreen(
       onDetectingChanged: (v) => setState(() => _isDetecting = v),
     ),
-    const NavigationScreen(withObstacleDetection: false),
+    NavigationScreen(key: _navigationKey, withObstacleDetection: false),
     const NavigationScreen(withObstacleDetection: true),
     SettingsScreen(scrollController: _settingsScrollController),
   ];


### PR DESCRIPTION
## 📎 Issue 번호
#96 

## 📄 작업 내용 요약
- `layout.dart`: `_navigationKey`가 NavigationScreen 위젯에 연결되지 않아 `initLocationIfNeeded()`가 호출되지 않던 버그 수정                                                                              
- `navigation_screen.dart`: `getCurrentLocation()` 내 타임아웃 체인 추가, 위치 실패 시 재시도 버튼 표시, geolocator 스트림 충돌 방지를 위해 `pushNamed` 이전에 스트림 취소                              
- `navigation_ing_screen.dart`: navigation_screen 스트림이 살아있는 동안 geolocator가 두 번째 스트림에 이벤트를 전달하지 않아 `_onPositionUpdate`가 한 번도 호출되지 않던 근본 원인 해결                  
- `route_debug_overlay.dart`: GPS 정확도 실시간 표시 추가 (20m 초과 시 빨간색)

 ## 원인 분석                                                                                                                                                                                              
geolocator 플러그인은 동시에 두 개의 `getPositionStream()`을 지원하지 않음. 
navigation_screen의 `_positionStream`(distanceFilter:20)이 살아있는 상태에서 navigation_ing_screen이 스트림을 열면 두 번째 스트림은 이벤트를 받지 못함. 
`pushNamed` 이전 `await cancel()`로 해결.

## 📄 변경 사항
**lib/layout/layout.dart** : [FIX] 길찾기 탭 GlobalKey 미연결 버그 수정
- _navigationKey를 NavigationScreen 위젯에 할당하지 않아 currentState가 항상 null이 되던 문제 수정.
- initLocationIfNeeded()가 호출되지 않아 위치 초기화가 전혀 이루어지지 않았음.                                                                                                                                                                                   
                                                                                                                                                                                                            
**lib/features/navigation/navigation_screen.dart** : [FIX] 위치 초기화 타임아웃·실패 처리 및 geolocator 스트림 충돌 해결
- getCurrentLocation() 내부 getLastKnownPosition에 5초 타임아웃 추가 (응답 없이 무한 대기하던 문제 방지)                                                                                                                                                                     
- getCurrentPosition에도 10초 타임아웃 추가
- _initLocation() 전체에 30초 상위 타임아웃 적용                                                                                                                                                          
- 위치 취득 실패 시 에러 메시지 + 재시도 버튼 표시                                                                                                                                                        
- _positionStream 취소를 pushNamed 이전으로 이동 (navigation_ing_screen과 geolocator 스트림 동시 실행 충돌 방지)                                                                                                                                         
- navigation 복귀 후 _locationInitialized 초기화 누락 수정                                                                                                                                                
                                                                                                                                                                                                            
**lib/features/navigation/navigation_ing_screen.dart** : [FIX] 길안내 화면 GPS 스트림 미수신 문제 해결                                                                                                                                                             
- geolocator가 동시에 두 스트림을 지원하지 않아 navigation_screen의 스트림이 살아있는 동안 _onPositionUpdate가 호출되지 않던 문제 수정.
- navigation_screen이 pushNamed 이전에 스트림을 취소하므로 불필요한 600ms 딜레이 제거.                                                                                                                                                                                        
- GPS 정확도 추적 변수, 수신 로그, onError 핸들러 추가.                                                                                                                                                     
                                                                                                                                                                                                            
**lib/common/widgets/route_debug_overlay.dart** : [FEAT] 디버그 오버레이 GPS 정확도 실시간 표시 추가                                                                                                                                                      
- DEV 바에 acc:X.Xm 항목 추가.                                                                                                                                                                              
- 정확도 20m 초과(필터링 대상)이면 빨간색으로 표시해 GPS 필터 임계값 초과 여부를 즉시 확인 가능하도록 개선.

## ✅ 체크리스트
- [ ] 길찾기 탭 진입 시 현재 위치 정상 표시
- [ ] 안내 시작 후 디버그 오버레이에 `acc:X.Xm` 값 표시 확인
- [ ] Start overview TTS 정상 출력                                                                                                                                                                        
- [ ] 이동 중 거리값이 연속적으로 감소하는지 확인                                                                                                                                                         
- [ ] 안내 종료 후 길찾기 탭 복귀 시 위치 재초기화 정상 동작