### PR TITLE
[FIX/FEAT] 반복 길찾기 GPS 스트림 충돌 전면 수정 및 길찾기 전용·통합모드 UI 개선

### DIFF
--- a/frontend/lib/features/navigation/navigation_ing_screen.dart
+++ b/frontend/lib/features/navigation/navigation_ing_screen.dart
@@ -590,6 +590,7 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
                                 ? (_route!.totalTime / 60).ceil()
                                 : 0,
                             status: _routeStatus,
+                            showStatus: _withObstacleDetection,
                           ),
                         ),
                         Padding(

--- a/frontend/lib/features/navigation/navigation_overview_card.dart
+++ b/frontend/lib/features/navigation/navigation_overview_card.dart
@@ -5,15 +5,17 @@ import 'package:safepath/common/theme/text_styles.dart';
 enum RouteStatus { safe, warning, danger }
 
 class NavigationOverviewCard extends StatelessWidget {
-  final int distance; // 남은 거리
-  final int time; // 남은 소요 시간
+  final int distance;
+  final int time;
   final RouteStatus status;
+  final bool showStatus;
 
   const NavigationOverviewCard({
     super.key,
     required this.distance,
     required this.time,
     required this.status,
+    this.showStatus = true,
   });
 
   String _getStatusText(RouteStatus status) {
@@ -60,8 +62,9 @@ class NavigationOverviewCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final semanticLabel =
-        '총 거리 ${_formatDistance(distance)}, 총 소요시간 ${_formatTime(time)}, 경로 상태 ${_getStatusText(status)}';
+    final semanticLabel = showStatus
+        ? '총 거리 ${_formatDistance(distance)}, 총 소요시간 ${_formatTime(time)}, 경로 상태 ${_getStatusText(status)}'
+        : '총 거리 ${_formatDistance(distance)}, 총 소요시간 ${_formatTime(time)}';
     return Semantics(
       label: semanticLabel,
       excludeSemantics: true,
@@ -94,54 +97,76 @@ class NavigationOverviewCard extends StatelessWidget {
             const SizedBox(height: 8),
             Divider(color: ColorCollection.point, thickness: 2),
             const SizedBox(height: 8),
-            Row(
-              children: [
-                Expanded(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        _formatTime(time),
-                        style: AppTextStyles.title2.copyWith(
-                          color: ColorCollection.point,
-                          fontSize: 20,
+            if (showStatus)
+              Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          _formatTime(time),
+                          style: AppTextStyles.title2.copyWith(
+                            color: ColorCollection.point,
+                            fontSize: 20,
+                          ),
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        '총 소요 시간',
-                        style: AppTextStyles.labelBold.copyWith(
-                          color: ColorCollection.point,
+                        const SizedBox(height: 8),
+                        Text(
+                          '총 소요 시간',
+                          style: AppTextStyles.labelBold.copyWith(
+                            color: ColorCollection.point,
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
-                ),
-                Expanded(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        _getStatusText(status),
-                        style: AppTextStyles.title2.copyWith(
-                          color: _getStatusColor(status),
-                          fontSize: 20,
+                  Expanded(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          _getStatusText(status),
+                          style: AppTextStyles.title2.copyWith(
+                            color: _getStatusColor(status),
+                            fontSize: 20,
+                          ),
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        '경로 상태',
-                        style: AppTextStyles.labelBold.copyWith(
-                          color: ColorCollection.point,
+                        const SizedBox(height: 8),
+                        Text(
+                          '경로 상태',
+                          style: AppTextStyles.labelBold.copyWith(
+                            color: ColorCollection.point,
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
-                ),
-              ],
-            ),
+                ],
+              )
+            else
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _formatTime(time),
+                    style: AppTextStyles.title2.copyWith(
+                      color: ColorCollection.point,
+                      fontSize: 20,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '총 소요 시간',
+                    style: AppTextStyles.labelBold.copyWith(
+                      color: ColorCollection.point,
+                    ),
+                  ),
+                ],
+              ),
           ],
         ),
       ),

--- a/frontend/lib/features/navigation/navigation_screen.dart
+++ b/frontend/lib/features/navigation/navigation_screen.dart
@@ -22,8 +22,13 @@ import 'package:safepath/service/vibration_service.dart';
 
 class NavigationScreen extends StatefulWidget {
   final bool withObstacleDetection;
+  final Future<void> Function()? onBeforeNavigationStart;
 
-  const NavigationScreen({super.key, this.withObstacleDetection = true});
+  const NavigationScreen({
+    super.key,
+    this.withObstacleDetection = true,
+    this.onBeforeNavigationStart,
+  });
 
   @override
   NavigationScreenState createState() => NavigationScreenState();
@@ -85,10 +90,20 @@ class NavigationScreenState extends State<NavigationScreen>
     _initLocation();
   }
 
+  /// 다른 NavigationScreen 인스턴스가 길찾기 시작 전 호출해 스트림 충돌 방지.
+  Future<void> cancelPositionStream() async {
+    await _positionStream?.cancel();
+    _positionStream = null;
+  }
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     // 앱 복귀 시 위치 미초기화 상태이면 재시도 (설정에서 권한 허용 후 복귀 대응)
-    if (state == AppLifecycleState.resumed && _currentPosition == null && mounted) {
+    // _locationInitialized가 true일 때만 — 한 번도 방문하지 않은 탭은 재시도 불필요
+    if (state == AppLifecycleState.resumed &&
+        _locationInitialized &&
+        _currentPosition == null &&
+        mounted) {
       _initLocation();
     }
   }
@@ -291,9 +306,11 @@ class NavigationScreenState extends State<NavigationScreen>
 
       if (!mounted) return;
 
-      // navigation_ing_screen이 열리기 전에 스트림을 취소해야 geolocator 스트림 충돌 방지
+      // 자신의 스트림 취소 후, 다른 NavigationScreen 스트림도 취소
+      // (geolocator는 동시 스트림을 지원하지 않아 navigation_ing_screen 스트림이 이벤트를 못 받음)
       await _positionStream?.cancel();
       _positionStream = null;
+      await widget.onBeforeNavigationStart?.call();
 
       if (!mounted) return;
 
@@ -329,41 +346,29 @@ class NavigationScreenState extends State<NavigationScreen>
   }
 
   /// 현재 위치 위도,경도 가져오기
+  ///
+  /// getPositionStream()을 쓰지 않는 이유: firstWhere()가 완료돼도 스트림이 즉시
+  /// 해제되지 않아 navigation_ing_screen의 GPS 스트림과 충돌함. 일회성 호출만 사용.
   Future<Position> getCurrentLocation() async {
-    bool serviceEnabled;
-    LocationPermission permission;
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) throw Exception('위치 서비스가 꺼져 있습니다.');
 
-    // 위치 서비스 활성화 확인
-    serviceEnabled = await Geolocator.isLocationServiceEnabled();
-    if (!serviceEnabled) {
-      throw Exception('위치 서비스가 꺼져 있습니다.');
-    }
-
-    // 권한 확인 (시스템 팝업은 온보딩에서만 요청 — 여기서는 상태 확인만)
-    permission = await Geolocator.checkPermission();
+    final permission = await Geolocator.checkPermission();
     if (permission == LocationPermission.denied ||
         permission == LocationPermission.deniedForever) {
       throw Exception('위치 권한이 거부되었습니다.');
     }
 
-    // 정확도 20m 이하인 첫 번째 위치 반환 (최대 10초 대기, 초과 시 폴백)
+    // 캐시된 위치가 있으면 먼저 반환 (정확도 50m 이내)
     try {
-      return await Geolocator.getPositionStream(
-        locationSettings: AndroidSettings(
-          accuracy: LocationAccuracy.best,
-          distanceFilter: 0,
-        ),
-      ).firstWhere((p) => p.accuracy <= 20).timeout(const Duration(seconds: 10));
-    } catch (_) {
-      try {
-        final last = await Geolocator.getLastKnownPosition()
-            .timeout(const Duration(seconds: 5));
-        if (last != null) return last;
-      } catch (_) {}
-      return await Geolocator.getCurrentPosition(
-        desiredAccuracy: LocationAccuracy.best,
-      ).timeout(const Duration(seconds: 10));
-    }
+      final last = await Geolocator.getLastKnownPosition()
+          .timeout(const Duration(seconds: 3));
+      if (last != null && last.accuracy <= 50) return last;
+    } catch (_) {}
+
+    return await Geolocator.getCurrentPosition(
+      desiredAccuracy: LocationAccuracy.best,
+    ).timeout(const Duration(seconds: 15));
   }
 
 
@@ -440,7 +445,7 @@ class NavigationScreenState extends State<NavigationScreen>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: CustomTitleBar(title: '길찾기'),
+      appBar: CustomTitleBar(title: widget.withObstacleDetection ? '통합모드' : '길찾기'),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),

--- a/frontend/lib/layout/layout.dart
+++ b/frontend/lib/layout/layout.dart
@@ -28,8 +28,18 @@ class _MainLayoutState extends State<MainLayout> {
     DetectionScreen(
       onDetectingChanged: (v) => setState(() => _isDetecting = v),
     ),
-    NavigationScreen(key: _navigationKey, withObstacleDetection: false),
-    NavigationScreen(key: _integratedKey, withObstacleDetection: true),
+    NavigationScreen(
+      key: _navigationKey,
+      withObstacleDetection: false,
+      onBeforeNavigationStart: () async =>
+          _integratedKey.currentState?.cancelPositionStream(),
+    ),
+    NavigationScreen(
+      key: _integratedKey,
+      withObstacleDetection: true,
+      onBeforeNavigationStart: () async =>
+          _navigationKey.currentState?.cancelPositionStream(),
+    ),
     SettingsScreen(scrollController: _settingsScrollController),
   ];
 
@@ -41,10 +51,9 @@ class _MainLayoutState extends State<MainLayout> {
       // 최초 로그인 후 1회만 권한 온보딩 표시
       await PermissionOnboardingSheet.showOnce(context);
       // 온보딩 완료 후 위치 초기화 (권한 허용 여부와 무관하게 시도 — 내부에서 denied 처리)
-      if (mounted) {
-        _navigationKey.currentState?.initLocationIfNeeded();
-        _integratedKey.currentState?.initLocationIfNeeded();
-      }
+      // 앱 시작 시 길찾기 탭만 초기화 — 통합 탭은 탭 전환 시 초기화
+      // (두 화면 동시 초기화 시 geolocator 스트림 충돌 발생)
+      if (mounted) _navigationKey.currentState?.initLocationIfNeeded();
     });
   }
 


### PR DESCRIPTION
## 📎 Issue 번호
#73 #96 

## 📄 작업 내용 요약
- `layout.dart`: 앱 시작 시 두 NavigationScreen 동시 초기화 제거, 상호 스트림 취소 콜백 연결                                                                                                              
- `navigation_screen.dart`: GPS 스트림 충돌 전면 수정, 타이틀바 모드별 분기 ('길찾기' / '통합모드')                                                                                                       
- `navigation_ing_screen.dart`: 길찾기 전용 모드에서 `showStatus: false` 전달                                                                                                                             
- `navigation_overview_card.dart`: `showStatus` 파라미터 추가, false 시 소요 시간만 중앙 표시

**lib/layout/layout.dart** : [FIX] 앱 시작 시 두 NavigationScreen 동시 초기화로 인한 GPS 스트림 충돌 수정                                                                                                                              
- 통합 탭을 앱 시작 시 함께 초기화하면 두 화면이 동시에 getPositionStream()을 열어 geolocator가 블로킹되는 문제 수정.                                                                                                                                             
- 앱 시작 시 길찾기 탭만 초기화하고, 통합 탭은 탭 전환 시 초기화.                                                                                                                                           
- 각 탭에서 길찾기 시작 전 상대방 스트림을 취소하는 콜백 연결.                                                                                                                                              
                                                                                                                                                                                                            
**lib/features/navigation/navigation_screen.dart** : [FIX/FEAT] 반복 길찾기 GPS 스트림 충돌 전면 수정 및 통합모드 UI 개선                                                                                                                                      
- cancelPositionStream() public 메서드 추가: 상대방 NavigationScreen 인스턴스가 pushNamed 전에 호출해 충돌 방지                                                                                                                                      
- onBeforeNavigationStart 콜백 파라미터 추가: startNavigation()에서 자신 + 상대방 스트림 모두 취소 후 화면 전환                                                                                                                                       
- getCurrentLocation() 스트림 제거: getPositionStream().firstWhere()는 완료 후에도 스트림이 즉시 해제되지 않아 2회차 이후 navigation_ing_screen 스트림과 충돌하던 문제 수정.                                                                                                                                           getLastKnownPosition + getCurrentPosition 일회성 호출로 대체.                                                                                                                                           
- didChangeAppLifecycleState에 _locationInitialized 조건 추가: 한 번도 방문하지 않은 탭이 앱 재개마다 스트림을 여는 것 방지                                                                                                                                            
- 타이틀바 텍스트를 withObstacleDetection 여부에 따라 분기: 통합모드는 '통합모드', 길찾기 전용은 '길찾기'                                                                                                                                                           
                                                                                                                                                                                                            
**lib/features/navigation/navigation_ing_screen.dart** : [FEAT] 길찾기 전용 모드에서 경로 상태 위젯 숨김 처리                                                                                                                                                    
- withObstacleDetection이 false일 때 NavigationOverviewCard의 경로 상태 영역을 표시하지 않도록 showStatus 파라미터 전달.                                                                                                                                                
                                                                                               
**lib/features/navigation/navigation_overview_card.dart** : [FEAT] 길찾기 전용 모드 지원을 위한 showStatus 파라미터 추가                                                                                                                                              
- showStatus가 false이면 경로 상태 열을 제거하고 소요 시간만 중앙 정렬로 표시.                                                                                                                                                                             
- 접근성 시맨틱 레이블도 showStatus에 따라 분기.

## 원인 분석                                                                                                                                                                                            
geolocator는 동시에 두 스트림을 지원하지 않음. 아래 세 가지 경로로 스트림이 겹쳐 `_onPositionUpdate`가 호출되지 않았음
1. 앱 시작 시 두 탭 동시 초기화 → 스트림 2개 동시 오픈                                                                                                                                                    
2. 타 탭 NavigationScreen의 `_positionStream`이 살아있는 상태에서 길찾기 시작                                                                                                                           
3. `getCurrentLocation()` 내 `getPositionStream().firstWhere()`가 2회차 이후에도 열려 있어 충돌                                                                                                           
                                                                                                                                                                                                          
세 케이스 모두 수정하여 반복 실행 시에도 start overview TTS가 정상 출력됨을 확인.

## 📸 스크린샷 (UI 변경 시 작성, 없으면 삭제)
<img width="2340" height="1080" alt="0513_19" src="https://github.com/user-attachments/assets/e19adf89-1f79-436c-ad7b-f2e050a240e6" />


## ✅ 체크리스트
- [x] 길찾기 탭 타이틀 '길찾기', 통합 탭 타이틀 '통합모드' 표시 확인                                                                                                                                      
- [x] 길찾기 탭에서 안내 시작 → start overview TTS 정상 출력                                                                                                                                            
- [x] 안내 종료 후 재시작 → 2회, 3회 반복 시에도 동일하게 동작                                                                                                                                            
- [x] 통합 탭에서도 동일하게 반복 안내 정상 동작                                                                                                                                                        
- [x] 길찾기 전용 모드 overview 카드에 소요 시간만 표시                                                                                                                                                   
- [x] 통합 모드 overview 카드에 소요 시간 + 경로 상태 표시

## 💬 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분, 우려 사항, 논의할 내용 등 -->