### PR TITLE
[FEAT] 날씨 TTS 안내 기능 구현

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,4 @@
 # Default ignored files
 /shelf/
 /workspace.xml
+/misc.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectRootManager">
-    <output url="file://$PROJECT_DIR$/out" />
-  </component>
-</project>

--- a/frontend/android/app/build.gradle.kts
+++ b/frontend/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.safepath"
+    namespace = "com.retriever.gilbeot"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.safepath"
+        applicationId = "com.retriever.gilbeot"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -37,11 +37,27 @@ android {
         manifestPlaceholders["kakaoNativeAppKey"] = localProps.getProperty("kakaoNativeAppKey", "")
     }
 
+    val localProps = Properties()
+    val localPropsFile = rootProject.file("local.properties")
+    if (localPropsFile.exists()) localProps.load(localPropsFile.inputStream())
+
+    signingConfigs {
+        create("release") {
+            val sf = localProps.getProperty("storeFile")
+            if (sf != null) {
+                storeFile = file(sf)
+                storePassword = localProps.getProperty("storePassword", "")
+                keyAlias = localProps.getProperty("keyAlias", "")
+                keyPassword = localProps.getProperty("keyPassword", "")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            val sf = localProps.getProperty("storeFile")
+            signingConfig = if (sf != null) signingConfigs.getByName("release")
+                            else signingConfigs.getByName("debug")
         }
     }
 }

--- a/frontend/android/app/src/main/kotlin/com/example/safepath/MainActivity.kt
+++ b/frontend/android/app/src/main/kotlin/com/example/safepath/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.safepath
+package com.retriever.gilbeot
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/frontend/ios/Flutter/Debug.xcconfig
+++ b/frontend/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+
+// 카카오 네이티브 앱키 — android/local.properties의 kakaoNativeAppKey와 동일한 값으로 설정
+KAKAO_NATIVE_APP_KEY = e96a398c95e8e4341727a29ae27bdd8e

--- a/frontend/ios/Flutter/Release.xcconfig
+++ b/frontend/ios/Flutter/Release.xcconfig
@@ -1,2 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+
+// 카카오 네이티브 앱키 — android/local.properties의 kakaoNativeAppKey와 동일한 값으로 설정
+KAKAO_NATIVE_APP_KEY = e96a398c95e8e4341727a29ae27bdd8e

--- a/frontend/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/frontend/ios/Runner/AppDelegate.swift
+++ b/frontend/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import KakaoSDKAuth
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -9,5 +10,16 @@ import UIKit
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    if AuthApi.isKakaoTalkLoginUrl(url) {
+      return AuthController.handleOpenUrl(url: url)
+    }
+    return false
   }
 }

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -53,5 +53,26 @@
 	<string>목적지 음성 입력을 위해 음성 인식 기능이 필요합니다.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>실시간 위치 기반 길안내를 위해 위치 접근이 필요합니다.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaotalk</string>
+	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/frontend/lib/layout/layout.dart
+++ b/frontend/lib/layout/layout.dart
@@ -81,7 +81,7 @@ class _MainLayoutState extends State<MainLayout> {
       debugPrint(
         '🌤 [Weather] 위치: ${position.latitude}, ${position.longitude}',
       );
-      final description = await WeatherService().fetchDescription(
+      final description = await WeatherService().fetchWeatherMessage(
         lat: position.latitude,
         lon: position.longitude,
       );

--- a/frontend/lib/layout/layout.dart
+++ b/frontend/lib/layout/layout.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/widgets/permission_onboarding_sheet.dart';
 import 'package:safepath/features/detection/detection_screen.dart';
@@ -6,7 +7,9 @@ import 'package:safepath/features/home/home_screen.dart';
 import 'package:safepath/features/navigation/navigation_screen.dart';
 import 'package:safepath/features/settings/settings_screen.dart';
 import 'package:safepath/service/sound_effect_service.dart';
+import 'package:safepath/service/tts_service.dart';
 import 'package:safepath/service/vibration_service.dart';
+import 'package:safepath/service/weather_service.dart';
 
 class MainLayout extends StatefulWidget {
   const MainLayout({super.key});
@@ -48,13 +51,56 @@ class _MainLayoutState extends State<MainLayout> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
+      debugPrint('🌤 [Weather] 온보딩 시작');
       // 최초 로그인 후 1회만 권한 온보딩 표시
       await PermissionOnboardingSheet.showOnce(context);
+      debugPrint('🌤 [Weather] 온보딩 완료, mounted: $mounted');
       // 온보딩 완료 후 위치 초기화 (권한 허용 여부와 무관하게 시도 — 내부에서 denied 처리)
       // 앱 시작 시 길찾기 탭만 초기화 — 통합 탭은 탭 전환 시 초기화
       // (두 화면 동시 초기화 시 geolocator 스트림 충돌 발생)
       if (mounted) _navigationKey.currentState?.initLocationIfNeeded();
+      _speakWeather();
     });
+  }
+
+  Future<void> _speakWeather() async {
+    debugPrint('🌤 [Weather] _speakWeather 시작');
+    try {
+      final permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever) {
+        debugPrint('🌤 [Weather] 위치 권한 없음 — 스킵');
+        return;
+      }
+      Position? position = await Geolocator.getLastKnownPosition()
+          .timeout(const Duration(seconds: 5))
+          .catchError((_) => null);
+      position ??= await Geolocator.getCurrentPosition(
+        desiredAccuracy: LocationAccuracy.low,
+      ).timeout(const Duration(seconds: 10));
+      debugPrint(
+        '🌤 [Weather] 위치: ${position.latitude}, ${position.longitude}',
+      );
+      final description = await WeatherService().fetchDescription(
+        lat: position.latitude,
+        lon: position.longitude,
+      );
+      debugPrint(
+        '🌤 [Weather] description 수신: $description, mounted: $mounted',
+      );
+      if (description != null && description.isNotEmpty && mounted) {
+        debugPrint('🌤 [Weather] TTS 호출');
+        await TtsService().speak(
+          description,
+          interrupt: false,
+          channel: TtsChannel.navigation,
+        );
+      } else {
+        debugPrint('🌤 [Weather] TTS 스킵 — description 없음 또는 unmounted');
+      }
+    } catch (e) {
+      debugPrint('🌤 [Weather] 위치 조회 실패: $e');
+    }
   }
 
   @override

--- a/frontend/lib/layout/layout.dart
+++ b/frontend/lib/layout/layout.dart
@@ -8,6 +8,7 @@ import 'package:safepath/features/navigation/navigation_screen.dart';
 import 'package:safepath/features/settings/settings_screen.dart';
 import 'package:safepath/service/sound_effect_service.dart';
 import 'package:safepath/service/tts_service.dart';
+import 'package:safepath/service/user_settings_service.dart';
 import 'package:safepath/service/vibration_service.dart';
 import 'package:safepath/service/weather_service.dart';
 
@@ -81,25 +82,32 @@ class _MainLayoutState extends State<MainLayout> {
       debugPrint(
         '🌤 [Weather] 위치: ${position.latitude}, ${position.longitude}',
       );
-      final description = await WeatherService().fetchWeatherMessage(
-        lat: position.latitude,
-        lon: position.longitude,
-      );
-      debugPrint(
-        '🌤 [Weather] description 수신: $description, mounted: $mounted',
-      );
-      if (description != null && description.isNotEmpty && mounted) {
-        debugPrint('🌤 [Weather] TTS 호출');
+
+      // 설정 로드와 날씨 API 호출을 병렬 처리
+      final results = await Future.wait([
+        UserSettingsService().fetch(),
+        WeatherService().fetchWeatherMessage(
+          lat: position.latitude,
+          lon: position.longitude,
+        ),
+      ]);
+      final settings = results[0] as UserSettings;
+      final message = results[1] as String?;
+
+      debugPrint('🌤 [Weather] message 수신: $message, mounted: $mounted');
+      if (message != null && message.isNotEmpty && mounted) {
+        await TtsService().setSpeechRate(settings.guidanceSpeed);
+        debugPrint('🌤 [Weather] TTS 호출 (speed: ${settings.guidanceSpeed})');
         await TtsService().speak(
-          description,
+          message,
           interrupt: false,
           channel: TtsChannel.navigation,
         );
       } else {
-        debugPrint('🌤 [Weather] TTS 스킵 — description 없음 또는 unmounted');
+        debugPrint('🌤 [Weather] TTS 스킵 — message 없음 또는 unmounted');
       }
     } catch (e) {
-      debugPrint('🌤 [Weather] 위치 조회 실패: $e');
+      debugPrint('🌤 [Weather] 오류: $e');
     }
   }
 

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -9,8 +9,8 @@ void main() async {
   KakaoSdk.init(nativeAppKey: kakaoNativeAppKey);
 
   // TODO: 키 해시 확인 후 삭제
-  final keyHash = await KakaoSdk.origin;
-  debugPrint('🔑 KEY HASH: $keyHash');
+  // final keyHash = await KakaoSdk.origin;
+  // debugPrint('🔑 KEY HASH: $keyHash');
 
   runApp(const App());
 }

--- a/frontend/lib/service/weather_service.dart
+++ b/frontend/lib/service/weather_service.dart
@@ -10,17 +10,84 @@ class WeatherService {
 
   static const String _baseUrl = String.fromEnvironment('BASE_URL');
 
-  Future<String?> fetchDescription({
+  // OpenWeather API description → 한국어 매핑 (공식 description 전체 목록)
+  static const Map<String, String> _descToKo = {
+    // Thunderstorm
+    'thunderstorm with light rain': '가벼운 비를 동반한 천둥번개',
+    'thunderstorm with rain': '비를 동반한 천둥번개',
+    'thunderstorm with heavy rain': '폭우를 동반한 천둥번개',
+    'light thunderstorm': '약한 천둥번개',
+    'thunderstorm': '천둥번개',
+    'heavy thunderstorm': '강한 천둥번개',
+    'ragged thunderstorm': '천둥번개',
+    'thunderstorm with light drizzle': '이슬비를 동반한 천둥번개',
+    'thunderstorm with drizzle': '이슬비를 동반한 천둥번개',
+    'thunderstorm with heavy drizzle': '이슬비를 동반한 천둥번개',
+    // Drizzle
+    'light intensity drizzle': '가벼운 이슬비',
+    'drizzle': '이슬비',
+    'heavy intensity drizzle': '강한 이슬비',
+    'light intensity drizzle rain': '가벼운 이슬비',
+    'drizzle rain': '이슬비',
+    'heavy intensity drizzle rain': '강한 이슬비',
+    'shower rain and drizzle': '소나기와 이슬비',
+    'heavy shower rain and drizzle': '강한 소나기와 이슬비',
+    'shower drizzle': '이슬비',
+    // Rain
+    'light rain': '가벼운 비',
+    'moderate rain': '비',
+    'heavy intensity rain': '강한 비',
+    'very heavy rain': '매우 강한 비',
+    'extreme rain': '폭우',
+    'freezing rain': '빙판 비',
+    'light intensity shower rain': '가벼운 소나기',
+    'shower rain': '소나기',
+    'heavy intensity shower rain': '강한 소나기',
+    'ragged shower rain': '소나기',
+    // Snow
+    'light snow': '약한 눈',
+    'snow': '눈',
+    'heavy snow': '폭설',
+    'sleet': '진눈깨비',
+    'light shower sleet': '약한 진눈깨비',
+    'shower sleet': '진눈깨비',
+    'light rain and snow': '비와 눈',
+    'rain and snow': '비와 눈',
+    'light shower snow': '약한 눈',
+    'shower snow': '눈',
+    'heavy shower snow': '폭설',
+    // Atmosphere
+    'mist': '안개',
+    'smoke': '연기',
+    'haze': '실안개',
+    'sand/dust whirls': '황사',
+    'fog': '짙은 안개',
+    'sand': '황사',
+    'dust': '먼지',
+    'volcanic ash': '화산재',
+    'squalls': '돌풍',
+    'tornado': '토네이도',
+    // Clear
+    'clear sky': '맑음',
+    // Clouds
+    'few clouds': '구름 조금',
+    'few clouds: 11-25%': '구름 조금',
+    'scattered clouds': '구름 많음',
+    'scattered clouds: 25-50%': '구름 많음',
+    'broken clouds': '흐림',
+    'broken clouds: 51-84%': '흐림',
+    'overcast clouds': '흐림',
+    'overcast clouds: 85-100%': '흐림',
+  };
+
+  Future<String?> fetchWeatherMessage({
     required double lat,
     required double lon,
   }) async {
     debugPrint('🌤 [Weather] API 호출: $_baseUrl/api/weather?lat=$lat&lon=$lon');
     try {
       final uri = Uri.parse('$_baseUrl/api/weather').replace(
-        queryParameters: {
-          'lat': lat.toString(),
-          'lon': lon.toString(),
-        },
+        queryParameters: {'lat': lat.toString(), 'lon': lon.toString()},
       );
       final response = await ApiClient().get(uri);
       debugPrint('🌤 [Weather] 응답 status: ${response.statusCode}');
@@ -28,9 +95,18 @@ class WeatherService {
       if (response.statusCode == 200) {
         final body = jsonDecode(response.body) as Map<String, dynamic>;
         if (body['success'] == true) {
-          final description = body['data']['description'] as String?;
-          debugPrint('🌤 [Weather] description: $description');
-          return description;
+          final data = body['data'] as Map<String, dynamic>;
+          final description = data['description'] as String? ?? '';
+          final temperature = (data['temperature'] as num?)?.toDouble() ?? 0;
+          final windSpeed = (data['windSpeed'] as num?)?.toDouble() ?? 0;
+          debugPrint('🌤 [Weather] description=$description, temp=$temperature, wind=$windSpeed');
+          final message = _buildMessage(
+            description: description,
+            temperature: temperature,
+            windSpeed: windSpeed,
+          );
+          debugPrint('🌤 [Weather] 생성된 멘트: $message');
+          return message;
         } else {
           debugPrint('🌤 [Weather] success=false');
         }
@@ -39,5 +115,61 @@ class WeatherService {
       debugPrint('🌤 [Weather] API 오류: $e\n$st');
     }
     return null;
+  }
+
+  String _buildMessage({
+    required String description,
+    required double temperature,
+    required double windSpeed,
+  }) {
+    final weatherKo = _descToKo[description.toLowerCase()] ?? description;
+
+    final String tempStr;
+    if (temperature < 0) {
+      final abs = temperature.abs();
+      final formatted = abs == abs.roundToDouble()
+          ? abs.toInt().toString()
+          : abs.toStringAsFixed(1);
+      tempStr = '영하 $formatted도';
+    } else {
+      final formatted = temperature == temperature.roundToDouble()
+          ? temperature.toInt().toString()
+          : temperature.toStringAsFixed(1);
+      tempStr = '$formatted도';
+    }
+
+    final buffer = StringBuffer('오늘 날씨는 $weatherKo, 기온은 $tempStr입니다.');
+
+    // 날씨 상황별 조언
+    final desc = description.toLowerCase();
+    if (desc.contains('thunderstorm')) {
+      buffer.write(' 천둥번개가 치고 있으니 야외 활동을 자제하세요.');
+    } else if (desc.contains('rain') || desc.contains('drizzle')) {
+      buffer.write(' 우산을 챙기세요.');
+    } else if (desc.contains('snow') || desc.contains('sleet')) {
+      buffer.write(' 눈길에 미끄럼을 주의하세요.');
+    } else if (desc.contains('fog') || desc.contains('mist') || desc.contains('haze')) {
+      buffer.write(' 시야가 좋지 않으니 주의하세요.');
+    } else if (desc.contains('sand') || desc.contains('dust')) {
+      buffer.write(' 마스크를 착용하세요.');
+    }
+
+    // 강풍 조언 (8m/s 이상일 때만)
+    if (windSpeed >= 12) {
+      buffer.write(' 강풍이 불고 있으니 외출 시 주의하세요.');
+    } else if (windSpeed >= 8) {
+      buffer.write(' 바람이 강하게 불고 있습니다.');
+    }
+
+    // 기온별 조언
+    if (temperature <= 0) {
+      buffer.write(' 따뜻하게 입고 외출하세요.');
+    } else if (temperature >= 33) {
+      buffer.write(' 폭염에 주의하고 수분을 충분히 섭취하세요.');
+    } else if (temperature >= 28) {
+      buffer.write(' 더위에 대비해 수분을 충분히 섭취하세요.');
+    }
+
+    return buffer.toString();
   }
 }

--- a/frontend/lib/service/weather_service.dart
+++ b/frontend/lib/service/weather_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:safepath/service/api_client.dart';
+
+class WeatherService {
+  static final WeatherService _instance = WeatherService._internal();
+  factory WeatherService() => _instance;
+  WeatherService._internal();
+
+  static const String _baseUrl = String.fromEnvironment('BASE_URL');
+
+  Future<String?> fetchDescription({
+    required double lat,
+    required double lon,
+  }) async {
+    debugPrint('🌤 [Weather] API 호출: $_baseUrl/api/weather?lat=$lat&lon=$lon');
+    try {
+      final uri = Uri.parse('$_baseUrl/api/weather').replace(
+        queryParameters: {
+          'lat': lat.toString(),
+          'lon': lon.toString(),
+        },
+      );
+      final response = await ApiClient().get(uri);
+      debugPrint('🌤 [Weather] 응답 status: ${response.statusCode}');
+      debugPrint('🌤 [Weather] 응답 body: ${response.body}');
+      if (response.statusCode == 200) {
+        final body = jsonDecode(response.body) as Map<String, dynamic>;
+        if (body['success'] == true) {
+          final description = body['data']['description'] as String?;
+          debugPrint('🌤 [Weather] description: $description');
+          return description;
+        } else {
+          debugPrint('🌤 [Weather] success=false');
+        }
+      }
+    } catch (e, st) {
+      debugPrint('🌤 [Weather] API 오류: $e\n$st');
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## 📎 Issue 번호
close #126 

## 📄 작업 내용 요약

앱 실행 시 현재 위치 기반으로 날씨 정보를 조회하고 TTS로 음성 안내하는 기능을 구현했습니다.

- `WeatherService` 추가: 위도/경도를 기반으로 `/api/weather` 엔드포인트 호출하여 날씨 설명 조회
- 날씨 상태값(영문) → 한국어 매핑 및 TTS용 문장 조합 로직 구현 (`WeatherService` 내)
- `Layout`에 날씨 TTS 안내 연동: 앱 진입 시 날씨 음성 안내 재생
- TTS 설정값(속도, 활성화 여부) 조회와 날씨 API 호출을 `Future.wait`으로 병렬 처리하여 응답 속도 개선


## ✅ 체크리스트

- [x] 빌드 및 실행이 정상 동작한다
- [x] Breaking change 없음 (있다면 작업 내용 요약에 명시)
- [x] 테스트를 했거나, 기존 테스트로 충분하다
- [x] 커밋 메시지가 작업 내용과 일치한다
- [x] 셀프 리뷰를 완료했다