### PR TITLE
[FEAT] iOS 권한 설정 및 카카오 로그인 빌드 환경 구성

### DIFF
--- a/frontend/android/app/build.gradle.kts
+++ b/frontend/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.safepath"
+    namespace = "com.retriever.gilbeot"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.safepath"
+        applicationId = "com.retriever.gilbeot"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -37,11 +37,27 @@ android {
         manifestPlaceholders["kakaoNativeAppKey"] = localProps.getProperty("kakaoNativeAppKey", "")
     }
 
+    val localProps = Properties()
+    val localPropsFile = rootProject.file("local.properties")
+    if (localPropsFile.exists()) localProps.load(localPropsFile.inputStream())
+
+    signingConfigs {
+        create("release") {
+            val sf = localProps.getProperty("storeFile")
+            if (sf != null) {
+                storeFile = file(sf)
+                storePassword = localProps.getProperty("storePassword", "")
+                keyAlias = localProps.getProperty("keyAlias", "")
+                keyPassword = localProps.getProperty("keyPassword", "")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            val sf = localProps.getProperty("storeFile")
+            signingConfig = if (sf != null) signingConfigs.getByName("release")
+                            else signingConfigs.getByName("debug")
         }
     }
 }

--- a/frontend/android/app/src/main/kotlin/com/example/safepath/MainActivity.kt
+++ b/frontend/android/app/src/main/kotlin/com/example/safepath/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.safepath
+package com.retriever.gilbeot
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/frontend/ios/Flutter/Debug.xcconfig
+++ b/frontend/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"
+
+// 카카오 네이티브 앱키 — android/local.properties의 kakaoNativeAppKey와 동일한 값으로 설정
+KAKAO_NATIVE_APP_KEY = e96a398c95e8e4341727a29ae27bdd8e

--- a/frontend/ios/Flutter/Release.xcconfig
+++ b/frontend/ios/Flutter/Release.xcconfig
@@ -1,2 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+
+// 카카오 네이티브 앱키 — android/local.properties의 kakaoNativeAppKey와 동일한 값으로 설정
+KAKAO_NATIVE_APP_KEY = e96a398c95e8e4341727a29ae27bdd8e

--- a/frontend/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.safepath;
+				PRODUCT_BUNDLE_IDENTIFIER = com.retriever.gilbeot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/frontend/ios/Runner/AppDelegate.swift
+++ b/frontend/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import KakaoSDKAuth
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -9,5 +10,16 @@ import UIKit
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    if AuthApi.isKakaoTalkLoginUrl(url) {
+      return AuthController.handleOpenUrl(url: url)
+    }
+    return false
   }
 }

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -53,5 +53,26 @@
 	<string>목적지 음성 입력을 위해 음성 인식 기능이 필요합니다.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>실시간 위치 기반 길안내를 위해 위치 접근이 필요합니다.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+		<string>kakaotalk</string>
+	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -9,8 +9,8 @@ void main() async {
   KakaoSdk.init(nativeAppKey: kakaoNativeAppKey);
 
   // TODO: 키 해시 확인 후 삭제
-  final keyHash = await KakaoSdk.origin;
-  debugPrint('🔑 KEY HASH: $keyHash');
+  // final keyHash = await KakaoSdk.origin;
+  // debugPrint('🔑 KEY HASH: $keyHash');
 
   runApp(const App());
 }


### PR DESCRIPTION
## 📎 Issue 번호
close #58 
close #64 

## 📄 작업 내용 요약

iOS 실행에 필요한 권한 선언, 오디오 세션, 카카오 로그인 연동 설정 및 Android 릴리즈 서명을 구성했습니다.

**iOS 권한 및 오디오 설정**
- `Info.plist`에 카메라·마이크 사용 목적 문구(NSCamera/NSMicrophone UsageDescription) 추가
- `Podfile` iOS 배포 타겟 13.0으로 상향
- `SoundEffectService`에 백그라운드 재생을 위한 오디오 세션(AVAudioSession) 초기화 설정 추가

**앱 ID 통일 및 카카오 로그인 설정**
- Bundle ID를 `com.retriever.gilbeot`으로 iOS·Android 통일 (`project.pbxproj`, `MainActivity.kt`)
- `Debug.xcconfig` / `Release.xcconfig`에 카카오 앱 키 환경변수 주입
- `Info.plist`에 카카오 URL Scheme 등록
- `AppDelegate.swift`에 카카오 SDK OAuth 2.0 URL 핸들러 추가

**Android 릴리즈 빌드**
- `build.gradle.kts`에 release 서명 설정 추가
- `main.dart` 디버그 전용 코드 제거

## ✅ 체크리스트

- [ ] 빌드 및 실행이 정상 동작한다
- [ ] Breaking change 없음 (있다면 작업 내용 요약에 명시)
- [ ] 테스트를 했거나, 기존 테스트로 충분하다
- [ ] 커밋 메시지가 작업 내용과 일치한다
- [ ] 셀프 리뷰를 완료했다